### PR TITLE
Make microbench library & header optional

### DIFF
--- a/exampleTop/configure/CONFIG_SITE
+++ b/exampleTop/configure/CONFIG_SITE
@@ -22,3 +22,9 @@ CHECK_RELEASE = YES
 
 -include $(TOP)/../../CONFIG_SITE.local
 -include $(TOP)/../configure/CONFIG_SITE.local
+
+ifdef WITH_MICROBENCH
+USR_CPPFLAGS += -DWITH_MICROBENCH
+MBLIB = pvMB
+endif
+

--- a/exampleTop/simpleDbPv/src/Makefile
+++ b/exampleTop/simpleDbPv/src/Makefile
@@ -14,7 +14,7 @@ PROD_IOC += simpleDbPv
 simpleDbPv_SRCS += simpleDbPv_registerRecordDeviceDriver.cpp
 simpleDbPv_SRCS_DEFAULT += simpleDbPvMain.cpp
 
-simpleDbPv_LIBS += pvaSrv pvAccess pvData pvMB
+simpleDbPv_LIBS += pvaSrv pvAccess pvData $(MBLIB)
 simpleDbPv_LIBS += $(EPICS_BASE_IOC_LIBS)
 
 simpleDbPv_SRCS_vxWorks += -nil-

--- a/testTop/configure/CONFIG_SITE
+++ b/testTop/configure/CONFIG_SITE
@@ -22,3 +22,9 @@ CHECK_RELEASE = YES
 
 -include $(TOP)/../../CONFIG_SITE.local
 -include $(TOP)/../configure/CONFIG_SITE.local
+
+ifdef WITH_MICROBENCH
+USR_CPPFLAGS += -DWITH_MICROBENCH
+MBLIB = pvMB
+endif
+

--- a/testTop/dbPv/src/Makefile
+++ b/testTop/dbPv/src/Makefile
@@ -47,7 +47,7 @@ testDbPv_SRCS_vxWorks += -nil-
 testDbPv_OBJS_vxWorks += $(EPICS_BASE_BIN)/vxComLibrary
 
 testDbPv_LIBS += testDbPvSupport
-testDbPv_LIBS += pvaSrv pvAccess pvData pvMB
+testDbPv_LIBS += pvaSrv pvAccess pvData $(MBLIB)
 testDbPv_LIBS += $(EPICS_BASE_IOC_LIBS)
 
 #===========================


### PR DESCRIPTION
Requires related changes in pvAccessCPP, and in pvCommonCPP if you're actually using the microbench code.