### PR TITLE
Fix monitor bug (#14)

### DIFF
--- a/src/dbPv/3.14/caMonitor.cpp
+++ b/src/dbPv/3.14/caMonitor.cpp
@@ -36,7 +36,7 @@ using epics::pvAccess::ca::dbrStatus2alarmStatus;
 
 CaData::CaData()
 : doubleValue(0.0),
-  sevr(0), stat(0), status(0)
+  sevr(0), stat(0), status("")
 {}
 
 CaData::~CaData()

--- a/src/dbPv/3.15/caMonitor.cpp
+++ b/src/dbPv/3.15/caMonitor.cpp
@@ -36,7 +36,7 @@ using epics::pvAccess::ca::dbrStatus2alarmStatus;
 
 CaData::CaData()
 : doubleValue(0.0),
-  sevr(0), stat(0), status(0)
+  sevr(0), stat(0), status("")
 {}
 
 CaData::~CaData()


### PR DESCRIPTION
<p>Fix issue #14 <p>

<p>Cause was CaData::status being initialised with null string in CaMonitor's constructor. Fixed by
changing to empty string.</p>
