### PR TITLE
Fix issues 1, 23 and 24

### DIFF
--- a/src/dbPv/3.14/dbPv.h
+++ b/src/dbPv/3.14/dbPv.h
@@ -366,7 +366,6 @@ private:
     int numberFree;
     int numberUsed;
     int nextGetFree;
-    int nextSetUsed;
     int nextGetUsed;
     int nextReleaseUsed;
     epics::pvData::Mutex mutex;
@@ -375,7 +374,6 @@ private:
     epics::pvData::MonitorElementPtrArray elements;
     epics::pvData::MonitorElementPtr currentElement;
     epics::pvData::MonitorElementPtr nullElement;
-    epics::pvData::MonitorElementPtrArray elementArray;
 };
 
 class DbPvArray :

--- a/src/dbPv/3.14/dbPvMonitor.cpp
+++ b/src/dbPv/3.14/dbPvMonitor.cpp
@@ -262,15 +262,24 @@ void DbPvMonitor::eventCallback(const char *status)
        pvStructure,
        overrunBitSet,
        &caData);
-    int index = overrunBitSet->nextSetBit(0);
-    while(index>=0) {
-        bool wasSet = bitSet->get(index);
-        if(!wasSet) {
-            bitSet->set(index);
-            overrunBitSet->clear(index);
+
+    if(firstTime) {
+        firstTime = false;
+        bitSet->clear();
+        overrunBitSet->clear();
+        bitSet->set(0);
+    } else {
+        int index = overrunBitSet->nextSetBit(0);
+        while(index>=0) {
+            bool wasSet = bitSet->get(index);
+            if(!wasSet) {
+                bitSet->set(index);
+                overrunBitSet->clear(index);
+            }
+            index = overrunBitSet->nextSetBit(index+1);
         }
-        index = overrunBitSet->nextSetBit(index+1);
     }
+    
     if(bitSet->nextSetBit(0)>=0) {
         nextElement =getFree();
         if(nextElement) {
@@ -281,11 +290,6 @@ void DbPvMonitor::eventCallback(const char *status)
         }
     }
     dbScanUnlock(dbAddr.precord);
-    if(firstTime) {
-        firstTime = false;
-        bitSet->clear();
-        bitSet->set(0);
-    }
     if(bitSet->nextSetBit(0)<0) return;
     if(!nextElement) return;
     numberUsed++;

--- a/src/dbPv/3.14/dbPvMonitor.cpp
+++ b/src/dbPv/3.14/dbPvMonitor.cpp
@@ -65,7 +65,6 @@ DbPvMonitor::DbPvMonitor(
   numberFree(queueSize),
   numberUsed(0),
   nextGetFree(0),
-  nextSetUsed(0),
   nextGetUsed(0),
   nextReleaseUsed(0),
   beingDestroyed(false),
@@ -295,8 +294,6 @@ void DbPvMonitor::eventCallback(const char *status)
     if(bitSet->nextSetBit(0)<0) return;
     if(!nextElement) return;
     numberUsed++;
-    nextSetUsed++;
-    if(nextSetUsed>=queueSize) nextSetUsed = 0;
     currentElement = nextElement;
     monitorRequester->monitorEvent(getPtrSelf());
 }

--- a/src/dbPv/3.14/dbPvMonitor.cpp
+++ b/src/dbPv/3.14/dbPvMonitor.cpp
@@ -88,6 +88,7 @@ bool DbPvMonitor::init(
         if(pvString) {
              string value = pvString->get();
              queueSize = atoi(value.c_str());
+             numberFree = queueSize;
         }
     }
     propertyMask = dbUtil->getProperties(

--- a/src/dbPv/3.14/dbPvMonitor.cpp
+++ b/src/dbPv/3.14/dbPvMonitor.cpp
@@ -178,6 +178,7 @@ Status DbPvMonitor::start()
         }
         if(isStarted) return Status::Ok;
         isStarted = true;
+        firstTime = true;
     }
     if(!currentElement) {
         currentElement = getFree();
@@ -187,8 +188,7 @@ Status DbPvMonitor::start()
         throw std::logic_error(
             "dbPvMonitor::start no free queue element");
     }
-    BitSet::shared_pointer bitSet = currentElement->changedBitSet;
-    bitSet->clear();
+
     caMonitor.get()->start();
     return Status::Ok;
 }

--- a/src/dbPv/3.14/dbPvMonitor.cpp
+++ b/src/dbPv/3.14/dbPvMonitor.cpp
@@ -180,7 +180,9 @@ Status DbPvMonitor::start()
         if(isStarted) return Status::Ok;
         isStarted = true;
     }
-    currentElement =getFree();
+    if(!currentElement) {
+        currentElement = getFree();
+    }
     if(!currentElement) {
         printf("dbPvMonitor::start will throw\n");
         throw std::logic_error(

--- a/src/dbPv/3.15/dbPv.h
+++ b/src/dbPv/3.15/dbPv.h
@@ -360,7 +360,6 @@ private:
     int numberFree;
     int numberUsed;
     int nextGetFree;
-    int nextSetUsed;
     int nextGetUsed;
     int nextReleaseUsed;
     epics::pvData::Mutex mutex;
@@ -369,7 +368,6 @@ private:
     epics::pvData::MonitorElementPtrArray elements;
     epics::pvData::MonitorElementPtr currentElement;
     epics::pvData::MonitorElementPtr nullElement;
-    epics::pvData::MonitorElementPtrArray elementArray;
 };
 
 class DbPvArray :

--- a/src/dbPv/3.15/dbPvMonitor.cpp
+++ b/src/dbPv/3.15/dbPvMonitor.cpp
@@ -178,8 +178,10 @@ Status DbPvMonitor::start()
         if(isStarted) return Status::Ok;
         isStarted = true;
     }
-    currentElement = getFree();
-    if (!currentElement) {
+    if(!currentElement) {
+        currentElement = getFree();
+    }
+    if(!currentElement) {
         printf("dbPvMonitor::start will throw\n");
         throw std::logic_error(
             "dbPvMonitor::start no free queue element");

--- a/src/dbPv/3.15/dbPvMonitor.cpp
+++ b/src/dbPv/3.15/dbPvMonitor.cpp
@@ -63,7 +63,6 @@ DbPvMonitor::DbPvMonitor(
   numberFree(queueSize),
   numberUsed(0),
   nextGetFree(0),
-  nextSetUsed(0),
   nextGetUsed(0),
   nextReleaseUsed(0),
   beingDestroyed(false),
@@ -293,8 +292,6 @@ void DbPvMonitor::eventCallback(const char *status)
     if(bitSet->nextSetBit(0)<0) return;
     if(!nextElement) return;
     numberUsed++;
-    nextSetUsed++;
-    if (nextSetUsed >= queueSize) nextSetUsed = 0;
     currentElement = nextElement;
     monitorRequester->monitorEvent(getPtrSelf());
 }

--- a/src/dbPv/3.15/dbPvMonitor.cpp
+++ b/src/dbPv/3.15/dbPvMonitor.cpp
@@ -260,15 +260,24 @@ void DbPvMonitor::eventCallback(const char *status)
        pvStructure,
        overrunBitSet,
        &caData);
-    int index = overrunBitSet->nextSetBit(0);
-    while(index>=0) {
-        bool wasSet = bitSet->get(index);
-        if(!wasSet) {
-            bitSet->set(index);
-            overrunBitSet->clear(index);
+
+    if(firstTime) {
+        firstTime = false;
+        bitSet->clear();
+        overrunBitSet->clear();
+        bitSet->set(0);
+    } else {
+        int index = overrunBitSet->nextSetBit(0);
+        while(index>=0) {
+            bool wasSet = bitSet->get(index);
+            if(!wasSet) {
+                bitSet->set(index);
+                overrunBitSet->clear(index);
+            }
+            index = overrunBitSet->nextSetBit(index+1);
         }
-        index = overrunBitSet->nextSetBit(index+1);
     }
+    
     if(bitSet->nextSetBit(0)>=0) {
         nextElement =getFree();
         if(nextElement) {
@@ -279,11 +288,6 @@ void DbPvMonitor::eventCallback(const char *status)
         }
     }
     dbScanUnlock(dbChannelRecord(dbPv->getDbChannel()));
-    if (firstTime) {
-        firstTime = false;
-        bitSet->clear();
-        bitSet->set(0);
-    }
     if(bitSet->nextSetBit(0)<0) return;
     if(!nextElement) return;
     numberUsed++;

--- a/src/dbPv/3.15/dbPvMonitor.cpp
+++ b/src/dbPv/3.15/dbPvMonitor.cpp
@@ -86,6 +86,7 @@ bool DbPvMonitor::init(
         if(pvString) {
              string value = pvString->get();
              queueSize = atoi(value.c_str());
+             numberFree = queueSize;
         }
     }
     propertyMask = dbUtil->getProperties(

--- a/src/dbPv/3.15/dbPvMonitor.cpp
+++ b/src/dbPv/3.15/dbPvMonitor.cpp
@@ -176,6 +176,7 @@ Status DbPvMonitor::start()
         }
         if(isStarted) return Status::Ok;
         isStarted = true;
+        firstTime = true;
     }
     if(!currentElement) {
         currentElement = getFree();
@@ -185,8 +186,7 @@ Status DbPvMonitor::start()
         throw std::logic_error(
             "dbPvMonitor::start no free queue element");
     }
-    BitSet::shared_pointer bitSet = currentElement->changedBitSet;
-    bitSet->clear();
+
     caMonitor.get()->start();
     return Status::Ok;
 }


### PR DESCRIPTION
<p>This fixes a number of related issues in pvaSrv monitoring. It makes the following changes:</p>

<ol>
<li>Sets initial number of free monitor elements to the queue size (previously was always 2). Fixes #24.
</li>
<li>Ensures the first update is sent on connection. Fixes #1.</li>
<li>Fixes an error restarting monitors (fixes #23). </li>
<li>Ensures overflow bits clear on monitor starts (matches pvDatabase behaviour)
</li>
<li>Ensures monitor updates sent on restarts (matches pvDatabase  behaviour, see issue #1).</li>
<li>Removes two unused variables.</li>
</ol>