### PR TITLE
getSubField -> getSubFieldT to avoid potential NULL de-ref.

### DIFF
--- a/src/dbGroup/dbGroupGet.cpp
+++ b/src/dbGroup/dbGroupGet.cpp
@@ -86,9 +86,9 @@ void DbGroupGet::get(bool lastRequest)
         if(alarm.getSeverity()>maxAlarm.getSeverity()) maxAlarm = alarm;
         convert->copy(pvValue,pvFields[i+2]);
     }
-    pvAlarm.attach(pvTop->getSubField("alarm"));
+    pvAlarm.attach(pvTop->getSubFieldT("alarm"));
     pvAlarm.set(maxAlarm);
-    pvTimeStamp.attach(pvTop->getSubField("timeStamp"));
+    pvTimeStamp.attach(pvTop->getSubFieldT("timeStamp"));
     timeStamp.getCurrent();
     pvTimeStamp.set(timeStamp);
     bitSet->clear();

--- a/src/dbPv/3.14/dbPv.cpp
+++ b/src/dbPv/3.14/dbPv.cpp
@@ -133,7 +133,6 @@ ChannelGet::shared_pointer DbPv::createChannelGet(
         ChannelGetRequester::shared_pointer const &channelGetRequester,
         PVStructure::shared_pointer const &pvRequest)
 {
-    PVFieldPtr pvField = pvRequest->getSubField("getField");
     DbPvGet::shared_pointer dbPvGet(
         new DbPvGet(getPtrSelf(),channelGetRequester,*(dbAddr.get())));
     if(!dbPvGet->init(pvRequest)) {
@@ -150,7 +149,6 @@ ChannelPut::shared_pointer DbPv::createChannelPut(
         ChannelPutRequester::shared_pointer const &channelPutRequester,
         PVStructure::shared_pointer const &pvRequest)
 {
-    PVFieldPtr pvField = pvRequest->getSubField("putField");
     DbPvPut::shared_pointer dbPvPut(
           new DbPvPut(getPtrSelf(),channelPutRequester,*(dbAddr.get())));
     if(!dbPvPut->init(pvRequest)) {

--- a/src/dbPv/3.14/dbPvMonitor.cpp
+++ b/src/dbPv/3.14/dbPvMonitor.cpp
@@ -82,9 +82,8 @@ bool DbPvMonitor::init(
     PVStructure::shared_pointer const &pvRequest)
 {
     string queueSizeString("record._options.queueSize");
-    PVFieldPtr pvField = pvRequest.get()->getSubField(queueSizeString);
-    if(pvField) {
-        PVStringPtr pvString = pvRequest.get()->getSubField<PVString>(queueSizeString);
+    {
+        PVStringPtr pvString = pvRequest->getSubField<PVString>(queueSizeString);
         if(pvString) {
              string value = pvString->get();
              queueSize = atoi(value.c_str());

--- a/src/dbPv/3.14/dbUtil.cpp
+++ b/src/dbPv/3.14/dbUtil.cpp
@@ -431,8 +431,7 @@ void  DbUtil::getPropertyData(
             display.setLow(graphics.lower_disp_limit);
         }
         PVDisplay pvDisplay;
-        PVFieldPtr pvField = pvStructure->getSubField(displayString);
-        pvDisplay.attach(pvField);
+        pvDisplay.attach(pvStructure->getSubFieldT(displayString));
         pvDisplay.set(display);
     }
     if(propertyMask&controlBit) {
@@ -448,8 +447,7 @@ void  DbUtil::getPropertyData(
             control.setLow(graphics.lower_ctrl_limit);
         }
         PVControl pvControl;
-        PVFieldPtr pvField = pvStructure->getSubField(controlString);
-        pvControl.attach(pvField);
+        pvControl.attach(pvStructure->getSubFieldT(controlString));
         pvControl.set(control);
     }
     if(propertyMask&valueAlarmBit) {
@@ -779,7 +777,7 @@ Status  DbUtil::get(
     if((propertyMask&timeStampBit)!=0) {
         TimeStamp timeStamp;
         PVTimeStamp pvTimeStamp;
-        PVFieldPtr pvField = pvStructure->getSubField(timeStampString);
+        PVFieldPtr pvField = pvStructure->getSubFieldT(timeStampString);
         if(!pvTimeStamp.attach(pvField)) {
             throw std::logic_error("V3ChannelGet::get logic error");
         }
@@ -807,7 +805,7 @@ Status  DbUtil::get(
     if((propertyMask&alarmBit)!=0) {
         Alarm alarm;
         PVAlarm pvAlarm;
-        PVFieldPtr pvField = pvStructure->getSubField(alarmString);
+        PVFieldPtr pvField = pvStructure->getSubFieldT(alarmString);
         if(!pvAlarm.attach(pvField)) {
             throw std::logic_error("V3ChannelGet::get logic error");
         }
@@ -1013,7 +1011,7 @@ Status  DbUtil::put(
             pvIndex = static_pointer_cast<PVInt>(pvField);
         } else {
             PVStructurePtr pvEnum = static_pointer_cast<PVStructure>(pvField);
-            pvIndex = pvEnum->getSubField<PVInt>(indexString);
+            pvIndex = pvEnum->getSubFieldT<PVInt>(indexString);
         }
         if(dbAddr.field_type==DBF_MENU) {
             requester->message("Not allowed to change a menu field",errorMessage);
@@ -1130,7 +1128,7 @@ Status  DbUtil::putField(
         PVIntPtr pvIndex;
         if(pvField->getField()->getType()==structure) {
             PVStructurePtr pvEnum = static_pointer_cast<PVStructure>(pvField);
-            pvIndex = pvEnum->getSubField<PVInt>(indexString);
+            pvIndex = pvEnum->getSubFieldT<PVInt>(indexString);
         } else {
             pvIndex = static_pointer_cast<PVInt>(pvField);
         }

--- a/src/dbPv/3.15/dbPvMonitor.cpp
+++ b/src/dbPv/3.15/dbPvMonitor.cpp
@@ -80,8 +80,7 @@ bool DbPvMonitor::init(
     PVStructure::shared_pointer const &pvRequest)
 {
     string queueSizeString("record._options.queueSize");
-    PVFieldPtr pvField = pvRequest.get()->getSubField(queueSizeString);
-    if(pvField) {
+    {
         PVStringPtr pvString = pvRequest.get()->getSubField<PVString>(queueSizeString);
         if(pvString) {
              string value = pvString->get();

--- a/src/dbPv/3.15/dbUtil.cpp
+++ b/src/dbPv/3.15/dbUtil.cpp
@@ -449,8 +449,7 @@ void  DbUtil::getPropertyData(
             display.setLow(graphics.lower_disp_limit);
         }
         PVDisplay pvDisplay;
-        PVFieldPtr pvField = pvStructure->getSubField(displayString);
-        pvDisplay.attach(pvField);
+        pvDisplay.attach(pvStructure->getSubFieldT(displayString));
         pvDisplay.set(display);
     }
     if(propertyMask&controlBit) {
@@ -466,8 +465,7 @@ void  DbUtil::getPropertyData(
             control.setLow(graphics.lower_ctrl_limit);
         }
         PVControl pvControl;
-        PVFieldPtr pvField = pvStructure->getSubField(controlString);
-        pvControl.attach(pvField);
+        pvControl.attach(pvStructure->getSubFieldT(controlString));
         pvControl.set(control);
     }
     if(propertyMask&valueAlarmBit) {
@@ -798,7 +796,7 @@ Status  DbUtil::get(
     if((propertyMask&timeStampBit)!=0) {
         TimeStamp timeStamp;
         PVTimeStamp pvTimeStamp;
-        PVFieldPtr pvField = pvStructure->getSubField(timeStampString);
+        PVFieldPtr pvField = pvStructure->getSubFieldT(timeStampString);
         if(!pvTimeStamp.attach(pvField)) {
             throw std::logic_error("V3ChannelGet::get logic error");
         }
@@ -826,7 +824,7 @@ Status  DbUtil::get(
     if((propertyMask&alarmBit)!=0) {
         Alarm alarm;
         PVAlarm pvAlarm;
-        PVFieldPtr pvField = pvStructure->getSubField(alarmString);
+        PVFieldPtr pvField = pvStructure->getSubFieldT(alarmString);
         if(!pvAlarm.attach(pvField)) {
             throw std::logic_error("V3ChannelGet::get logic error");
         }
@@ -1034,7 +1032,7 @@ Status  DbUtil::put(
             pvIndex = static_pointer_cast<PVInt>(pvField);
         } else {
             PVStructurePtr pvEnum = static_pointer_cast<PVStructure>(pvField);
-            pvIndex = pvEnum->getSubField<PVInt>(indexString);
+            pvIndex = pvEnum->getSubFieldT<PVInt>(indexString);
         }
         if (dbChannelFinalDBFType(dbChan) == DBF_MENU) {
             requester->message("Not allowed to change a menu field",errorMessage);
@@ -1151,7 +1149,7 @@ Status  DbUtil::putField(
         PVIntPtr pvIndex;
         if(pvField->getField()->getType()==structure) {
             PVStructurePtr pvEnum = static_pointer_cast<PVStructure>(pvField);
-            pvIndex = pvEnum->getSubField<PVInt>(indexString);
+            pvIndex = pvEnum->getSubFieldT<PVInt>(indexString);
         } else {
             pvIndex = static_pointer_cast<PVInt>(pvField);
         }


### PR DESCRIPTION
Fix a number of instances where the return values of getSubField() is dereferenced w/o checking for NULL.  Some are explicit, and some because PVDisplay::attach and similar assume the pointer argument is not NULL.

Same issue as epics-base/pvDataCPP#21