### PR TITLE
Remove WIN32 library list, wrong for Base-3.15

### DIFF
--- a/testTop/dbPv/src/Makefile
+++ b/testTop/dbPv/src/Makefile
@@ -31,7 +31,6 @@ testDbPvSupport_SRCS += ulongRecord.c
 testDbPvSupport_SRCS += bigstringinRecord.c
 testDbPvSupport_SRCS += waitRecord.c
 testDbPvSupport_SRCS += testDbPv.cpp
-testDbPvSupport_LIBS_WIN32 += pvAccess pvData dbIoc Com
 
 #=============================
 # Build an IOC application


### PR DESCRIPTION
This build change is necessary for building on Windows against Base-3.15. There should be no reason to have a windows-specific list of libraries to link against anyway.