### PR TITLE
initialize block in constructor

### DIFF
--- a/src/dbPv/3.14/dbPvGet.cpp
+++ b/src/dbPv/3.14/dbPvGet.cpp
@@ -40,9 +40,9 @@ DbPvGet::DbPvGet(
   channelGetRequester(channelGetRequester),
   dbAddr(dbAddr),
   process(false),
+  block(false),
   firstTime(true),
   propertyMask(0),
-  block(true),
   beingDestroyed(false)
 {
     if(DbPvDebug::getLevel()>0)printf("dbPvGet::dbPvGet\n");

--- a/src/dbPv/3.14/dbPvGet.cpp
+++ b/src/dbPv/3.14/dbPvGet.cpp
@@ -42,6 +42,7 @@ DbPvGet::DbPvGet(
   process(false),
   firstTime(true),
   propertyMask(0),
+  block(true),
   beingDestroyed(false)
 {
     if(DbPvDebug::getLevel()>0)printf("dbPvGet::dbPvGet\n");

--- a/src/dbPv/3.15/dbPvGet.cpp
+++ b/src/dbPv/3.15/dbPvGet.cpp
@@ -38,9 +38,9 @@ DbPvGet::DbPvGet(
   dbPv(dbPv),
   channelGetRequester(channelGetRequester),
   process(false),
+  block(false),
   firstTime(true),
   propertyMask(0),
-  block(true),
   beingDestroyed(false)
 {
     if(DbPvDebug::getLevel()>0)printf("dbPvGet::dbPvGet\n");

--- a/src/dbPv/3.15/dbPvGet.cpp
+++ b/src/dbPv/3.15/dbPvGet.cpp
@@ -40,6 +40,7 @@ DbPvGet::DbPvGet(
   process(false),
   firstTime(true),
   propertyMask(0),
+  block(true),
   beingDestroyed(false)
 {
     if(DbPvDebug::getLevel()>0)printf("dbPvGet::dbPvGet\n");


### PR DESCRIPTION
In the dbPvGet constructor block was not initialized.

The following is the fix
diff --git a/src/dbPv/3.14/dbPvGet.cpp b/src/dbPv/3.14/dbPvGet.cpp
index 4518ce0..ac5d76b 100644
--- a/src/dbPv/3.14/dbPvGet.cpp
+++ b/src/dbPv/3.14/dbPvGet.cpp
@@ -42,6 +42,7 @@ DbPvGet::DbPvGet(
   process(false),
   firstTime(true),
   propertyMask(0),
+  block(true),
   beingDestroyed(false)
 {
     if(DbPvDebug::getLevel()>0)printf("dbPvGet::dbPvGet\n");
diff --git a/src/dbPv/3.15/dbPvGet.cpp b/src/dbPv/3.15/dbPvGet.cpp
index 257d7b6..9e91efe 100644
--- a/src/dbPv/3.15/dbPvGet.cpp
+++ b/src/dbPv/3.15/dbPvGet.cpp
@@ -40,6 +40,7 @@ DbPvGet::DbPvGet(
   process(false),
   firstTime(true),
   propertyMask(0),
+  block(true),
   beingDestroyed(false)
 {
     if(DbPvDebug::getLevel()>0)printf("dbPvGet::dbPvGet\n");