### PR TITLE
lock before accessing class variables in stop

### DIFF
--- a/src/dbPv/3.14/caContext.cpp
+++ b/src/dbPv/3.14/caContext.cpp
@@ -83,6 +83,7 @@ void caContext::stop()
         //throw std::logic_error(String(
         //   "caContext::stop not same thread"));
     }
+    Lock xx(mutex);
     if(referenceCount!=0) {
         printf("caContext::stop referenceCount != 0 value %d\n",
             referenceCount);

--- a/src/dbPv/3.15/caContext.cpp
+++ b/src/dbPv/3.15/caContext.cpp
@@ -83,6 +83,7 @@ void caContext::stop()
         //throw std::logic_error(String(
         //   "caContext::stop not same thread"));
     }
+    Lock xx(mutex);
     if(referenceCount!=0) {
         printf("caContext::stop referenceCount != 0 value %d\n",
             referenceCount);


### PR DESCRIPTION
First let me thank Michael for weak pointer fixes.
While looking for the problem I did see one other bug.
In all methods of caContext.cpp except stop 
Lock xx(mutex);
was called before any class variables were accessed. 
It should also be done in the stop method.

When this was done before Michael's changes it always caused a server crash when a monitor client exited.

I have tested with both 3.14 and 3.15 and do not see any more crashes.