### PR TITLE
Support for additional Windows targets

### DIFF
--- a/src/dbPv/3.14/dbPvProvider.cpp
+++ b/src/dbPv/3.14/dbPvProvider.cpp
@@ -26,6 +26,7 @@
 #include <pv/noDefaultMethods.h>
 #include <pv/lock.h>
 
+#define epicsExportSharedSymbols
 #include "dbPv.h"
 #include "caSecurity.h"
 

--- a/src/dbPv/3.14/dbPvProvider.cpp
+++ b/src/dbPv/3.14/dbPvProvider.cpp
@@ -7,7 +7,7 @@
  * @author mrk
  */
 
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(NOMINMAX)
 #define NOMINMAX
 #endif
 

--- a/src/dbPv/3.15/dbPvProvider.cpp
+++ b/src/dbPv/3.15/dbPvProvider.cpp
@@ -26,6 +26,7 @@
 #include <pv/noDefaultMethods.h>
 #include <pv/lock.h>
 
+#define epicsExportSharedSymbols
 #include "dbPv.h"
 #include "caSecurity.h"
 

--- a/src/dbPv/3.15/dbPvProvider.cpp
+++ b/src/dbPv/3.15/dbPvProvider.cpp
@@ -7,7 +7,7 @@
  * @author mrk
  */
 
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(NOMINMAX)
 #define NOMINMAX
 #endif
 


### PR DESCRIPTION
These changes allow pvAccessCPP to be built for the Cygwin and MinGW targets, including cross-compiling for MinGW on Linux. A few other minor cleanups are included as well.