### PR TITLE
Fix Issue #38

### DIFF
--- a/src/dbPv/3.14/dbPv.cpp
+++ b/src/dbPv/3.14/dbPv.cpp
@@ -91,8 +91,17 @@ void DbPv::init()
         default:
           break;
     }
-    if(scalarType!=pvBoolean) {
-        bool isArray = (paddr->no_elements>1) ? true : false;
+    bool isArray = (paddr->no_elements>1) ? true : false;
+    if(scalarType==pvString) {
+        if(isArray) {
+            recordField = standardField->scalarArray(scalarType,
+                "value,timeStamp,alarm");
+        } else {
+            recordField = standardField->scalar(scalarType,
+                "value,timeStamp,alarm");
+        }
+    }
+    else if(scalarType!=pvBoolean) {
         if(isArray) {
             recordField = standardField->scalarArray(scalarType,
                 "value,timeStamp,alarm,display");

--- a/src/dbPv/3.14/dbPv.cpp
+++ b/src/dbPv/3.14/dbPv.cpp
@@ -98,7 +98,7 @@ void DbPv::init()
                 "value,timeStamp,alarm,display");
         } else {
             recordField = standardField->scalar(scalarType,
-                "value,timeStamp,alarm,display,control");
+                "value,timeStamp,alarm,display,control,valueAlarm");
         }
     }
 }

--- a/src/dbPv/3.14/dbUtil.cpp
+++ b/src/dbPv/3.14/dbUtil.cpp
@@ -263,10 +263,10 @@ int DbUtil::getProperties(
             if(fieldList.find(displayString)!=string::npos) {
                 propertyMask |= displayBit;
             }
-            if(fieldList.find(controlString)!=string::npos) {
+            if(type==scalar && fieldList.find(controlString)!=string::npos) {
                 propertyMask |= controlBit;
             }
-            if(fieldList.find(valueAlarmString)!=string::npos) {
+            if(type==scalar && fieldList.find(valueAlarmString)!=string::npos) {
                 propertyMask |= valueAlarmBit;
             }
             break;

--- a/src/dbPv/3.14/dbUtil.cpp
+++ b/src/dbPv/3.14/dbUtil.cpp
@@ -250,21 +250,30 @@ int DbUtil::getProperties(
         if(fieldList.find(alarmString)!=string::npos) {
             propertyMask |= alarmBit;
         }
-        if(fieldList.find(displayString)!=string::npos) {
-            if(dbAddr.field_type==DBF_LONG||dbAddr.field_type==DBF_DOUBLE) {
+        switch(dbAddr.field_type)
+        {
+        case DBF_CHAR:
+        case DBF_UCHAR:
+        case DBF_SHORT:
+        case DBF_USHORT:
+        case DBF_LONG:
+        case DBF_ULONG:
+        case DBF_FLOAT:
+        case DBF_DOUBLE:
+            if(fieldList.find(displayString)!=string::npos) {
                 propertyMask |= displayBit;
             }
-        }
-        if(fieldList.find(controlString)!=string::npos) {
-            if(dbAddr.field_type==DBF_LONG||dbAddr.field_type==DBF_DOUBLE) {
+            if(fieldList.find(controlString)!=string::npos) {
                 propertyMask |= controlBit;
             }
-        }
-        if(fieldList.find(valueAlarmString)!=string::npos) {
-            if(dbAddr.field_type==DBF_LONG||dbAddr.field_type==DBF_DOUBLE) {
+            if(fieldList.find(valueAlarmString)!=string::npos) {
                 propertyMask |= valueAlarmBit;
             }
+            break;
+        default:
+            break;
         }
+
     }
     if(propertyMask&enumValueBit) {
         pvField = pvRequest->getSubField(valueIndexString);

--- a/src/dbPv/3.15/dbPv.cpp
+++ b/src/dbPv/3.15/dbPv.cpp
@@ -90,8 +90,17 @@ void DbPv::init()
         default:
           break;
     }
-    if(scalarType!=pvBoolean) {
-        bool isArray = (dbChannelFinalElements(dbChan) > 1) ? true : false;
+    bool isArray = (dbChannelFinalElements(dbChan) > 1) ? true : false;
+    if(scalarType==pvString) {  
+        if(isArray) {
+            recordField = standardField->scalarArray(scalarType,
+                "value,timeStamp,alarm");
+        } else {
+            recordField = standardField->scalar(scalarType,
+                "value,timeStamp,alarm");
+        }
+    }
+    else if(scalarType!=pvBoolean) {
         if(isArray) {
             recordField = standardField->scalarArray(scalarType,
                 "value,timeStamp,alarm,display");

--- a/src/dbPv/3.15/dbPv.cpp
+++ b/src/dbPv/3.15/dbPv.cpp
@@ -97,7 +97,7 @@ void DbPv::init()
                 "value,timeStamp,alarm,display");
         } else {
             recordField = standardField->scalar(scalarType,
-                "value,timeStamp,alarm,display,control");
+                "value,timeStamp,alarm,display,control,valueAlarm");
         }
     }
 }

--- a/src/dbPv/3.15/dbUtil.cpp
+++ b/src/dbPv/3.15/dbUtil.cpp
@@ -266,20 +266,28 @@ int DbUtil::getProperties(
         if(fieldList.find(alarmString)!=string::npos) {
             propertyMask |= alarmBit;
         }
-        if(fieldList.find(displayString)!=string::npos) {
-            if(dbChannelFinalDBFType(dbChan)==DBF_LONG||dbChannelFinalDBFType(dbChan)==DBF_DOUBLE) {
+        switch(dbChannelFinalDBFType(dbChan))
+        {
+        case DBF_CHAR:
+        case DBF_UCHAR:
+        case DBF_SHORT:
+        case DBF_USHORT:
+        case DBF_LONG:
+        case DBF_ULONG:
+        case DBF_FLOAT:
+        case DBF_DOUBLE:
+            if(fieldList.find(displayString)!=string::npos) {
                 propertyMask |= displayBit;
             }
-        }
-        if(fieldList.find(controlString)!=string::npos) {
-            if(dbChannelFinalDBFType(dbChan)==DBF_LONG||dbChannelFinalDBFType(dbChan)==DBF_DOUBLE) {
+            if(fieldList.find(controlString)!=string::npos) {
                 propertyMask |= controlBit;
             }
-        }
-        if(fieldList.find(valueAlarmString)!=string::npos) {
-            if(dbChannelFinalDBFType(dbChan)==DBF_LONG||dbChannelFinalDBFType(dbChan)==DBF_DOUBLE) {
+            if(fieldList.find(valueAlarmString)!=string::npos) {
                 propertyMask |= valueAlarmBit;
             }
+            break;
+        default:
+            break;
         }
     }
     if(propertyMask&enumValueBit) {

--- a/src/dbPv/3.15/dbUtil.cpp
+++ b/src/dbPv/3.15/dbUtil.cpp
@@ -279,10 +279,10 @@ int DbUtil::getProperties(
             if(fieldList.find(displayString)!=string::npos) {
                 propertyMask |= displayBit;
             }
-            if(fieldList.find(controlString)!=string::npos) {
+            if(type==scalar && fieldList.find(controlString)!=string::npos) {
                 propertyMask |= controlBit;
             }
-            if(fieldList.find(valueAlarmString)!=string::npos) {
+            if(type==scalar && fieldList.find(valueAlarmString)!=string::npos) {
                 propertyMask |= valueAlarmBit;
             }
             break;


### PR DESCRIPTION
Simplest fix for this issue #38 seems to be to add valueAlarm to the structure returned by GetField. The structure will then match the data structure returned by Channel Get. This structure also matches the caProvider behaviour. 