### PR TITLE
Return all fields on request without field

### DIFF
--- a/src/dbPv/3.14/dbUtil.cpp
+++ b/src/dbPv/3.14/dbUtil.cpp
@@ -128,8 +128,8 @@ int DbUtil::getProperties(
     string fieldList;
     PVStructurePtr fieldPV = pvRequest->getSubField<PVStructure>(fieldString);
     if(fieldPV.get()==NULL) {
-        fieldList += valueString;
         getValue = true;
+        fieldList = allString;
     } else {
         if(fieldPV.get()!=NULL) pvRequest = fieldPV.get();
         if(pvRequest->getStructure()->getNumberFields()==0) {

--- a/src/dbPv/3.15/dbUtil.cpp
+++ b/src/dbPv/3.15/dbUtil.cpp
@@ -144,8 +144,8 @@ int DbUtil::getProperties(
     string fieldList;
     PVStructurePtr fieldPV = pvRequest->getSubField<PVStructure>(fieldString);
     if(fieldPV.get()==NULL) {
-        fieldList += valueString;
         getValue = true;
+        fieldList = allString;
     } else {
         if(fieldPV.get()!=NULL) pvRequest = fieldPV.get();
         if(pvRequest->getStructure()->getNumberFields()==0) {


### PR DESCRIPTION
When a client supplies a pvRequest structure without a "field" field current behaviour is to return just the value field.

Change to return all fields.