### PR TITLE
Fix issue #44

### DIFF
--- a/src/dbPv/3.14/dbUtil.cpp
+++ b/src/dbPv/3.14/dbUtil.cpp
@@ -755,7 +755,7 @@ Status  DbUtil::get(
                 if(dbAddr.field_type==DBF_DEVICE) {
                     val = static_cast<epicsEnum16>(dbAddr.precord->dtyp);
                 } else {
-                    val = *static_cast<int32 *>(dbAddr.pfield);
+                    val = static_cast<int32>(*static_cast<epicsEnum16 *>(dbAddr.pfield));
                 }
             }
             if((propertyMask&enumIndexBit)!=0) {

--- a/src/dbPv/3.15/dbUtil.cpp
+++ b/src/dbPv/3.15/dbUtil.cpp
@@ -774,7 +774,7 @@ Status  DbUtil::get(
                 if (dbChannelFinalDBFType(dbChan) == DBF_DEVICE) {
                     val = static_cast<epicsEnum16>(dbChannelRecord(dbChan)->dtyp);
                 } else {
-                    val = *static_cast<int32 *>(dbChannelField(dbChan));
+                    val = static_cast<int32>(*static_cast<epicsEnum16 *>(dbChannelField(dbChan)));
                 }
             }
             if((propertyMask&enumIndexBit)!=0) {


### PR DESCRIPTION
Enum value is stored as an epicsEnum16 (which is an unsigned 16-bit integer), but was treated as int32 in cast causing value to be correct only modulo 65536. Fix this.