### PR TITLE
Set property data on all gets/monitor updates

### DIFF
--- a/src/dbPv/3.14/dbPvGet.cpp
+++ b/src/dbPv/3.14/dbPvGet.cpp
@@ -67,7 +67,6 @@ bool DbPvGet::init(PVStructure::shared_pointer const &pvRequest)
                     propertyMask,
                     dbAddr));
     if (!pvStructure.get()) return false;
-    dbUtil->getPropertyData(channelGetRequester,propertyMask,dbAddr,pvStructure);
     int numFields = pvStructure->getNumberFields();
     bitSet.reset(new BitSet(numFields));
     if (propertyMask&dbUtil->processBit) {

--- a/src/dbPv/3.14/dbPvMonitor.cpp
+++ b/src/dbPv/3.14/dbPvMonitor.cpp
@@ -110,7 +110,6 @@ bool DbPvMonitor::init(
         elements.push_back(element);
     }
     MonitorElementPtr element = elements[0];
-    dbUtil->getPropertyData(monitorRequester,propertyMask,dbAddr,element->pvStructurePtr);
     StructureConstPtr saveStructure = element->pvStructurePtr->getStructure();
     if((propertyMask&dbUtil->enumValueBit)!=0) {
         caType = CaEnum;

--- a/src/dbPv/3.14/dbUtil.cpp
+++ b/src/dbPv/3.14/dbUtil.cpp
@@ -397,8 +397,24 @@ void  DbUtil::getPropertyData(
         int propertyMask,DbAddr &dbAddr,
         PVStructurePtr const &pvStructure)
 {
+    BitSet::shared_pointer bitSet;
+    getPropertyDataImpl(requester, propertyMask, dbAddr,
+        pvStructure, bitSet);
+}
+
+void  DbUtil::getPropertyDataImpl(
+        Requester::shared_pointer const &requester,
+        int propertyMask,DbAddr &dbAddr,
+        PVStructurePtr const &pvStructure,
+        BitSet::shared_pointer const &bitSet)
+{
     if(propertyMask&displayBit) {
         Display display;
+        PVDisplay pvDisplay;
+        PVStructurePtr displayField = pvStructure->getSubFieldT<PVStructure>(displayString);
+        pvDisplay.attach(displayField);
+        pvDisplay.get(display);
+        bool changed = false;
         char units[DB_UNITS_SIZE];
         units[0] = 0;
         long precision = 0;
@@ -407,19 +423,29 @@ void  DbUtil::getPropertyData(
             get_units gunits;
             gunits = (get_units)(prset->get_units);
             gunits(&dbAddr,units);
-            display.setUnits(units);
+            string unitsString = string(units);
+            if (unitsString != display.getUnits()) {
+                display.setUnits(units);
+                changed = true;
+            }
         }
         if(prset && prset->get_precision) {
             get_precision gprec = (get_precision)(prset->get_precision);
             gprec(&dbAddr,&precision);
+            string format;
             if(precision>0) {
                 char fmt[16];
                 sprintf(fmt,"%%.%ldf",precision);
-                display.setFormat(string(fmt));
+                format = string(fmt);
             }
             else {
-                static string defaultFormat("%f");
+                const static string defaultFormat("%f");
+                format = defaultFormat;
                 display.setFormat(defaultFormat);
+            }
+            if (format != display.getFormat()) {
+                display.setFormat(format);
+                changed = true;
             }
         }
         struct dbr_grDouble graphics;
@@ -427,28 +453,52 @@ void  DbUtil::getPropertyData(
             get_graphic_double gg =
                     (get_graphic_double)(prset->get_graphic_double);
             gg(&dbAddr,&graphics);
-            display.setHigh(graphics.upper_disp_limit);
-            display.setLow(graphics.lower_disp_limit);
+            if (display.getHigh() != graphics.upper_disp_limit) {
+                display.setHigh(graphics.upper_disp_limit);
+                changed = true;
+            }
+            if (display.getLow() != graphics.lower_disp_limit) {
+                display.setLow(graphics.lower_disp_limit);
+                changed = true;
+            }
+            
         }
-        PVDisplay pvDisplay;
-        pvDisplay.attach(pvStructure->getSubFieldT(displayString));
-        pvDisplay.set(display);
+        if (changed) {
+            pvDisplay.set(display);
+            if (bitSet.get()) 
+                bitSet->set(displayField->getFieldOffset());
+            else
+                std::cout << "display: bitset == null" << std::endl;
+        }
     }
     if(propertyMask&controlBit) {
+        PVControl pvControl;
+        PVStructurePtr controlField = pvStructure->getSubFieldT<PVStructure>(controlString);
+        pvControl.attach(controlField);
         Control control;
+        pvControl.get(control);
+        bool changed = false;
         struct rset *prset = dbGetRset(&dbAddr);
         struct dbr_ctrlDouble graphics;
         memset(&graphics,0,sizeof(graphics));
         if(prset && prset->get_control_double) {
             get_control_double cc =
                     (get_control_double)(prset->get_control_double);
-            cc(&dbAddr,&graphics);
-            control.setHigh(graphics.upper_ctrl_limit);
-            control.setLow(graphics.lower_ctrl_limit);
+            cc(&dbAddr, &graphics);
+            if (control.getHigh() != graphics.upper_ctrl_limit) {
+                control.setHigh(graphics.upper_ctrl_limit);
+                changed = true;
+            }
+            if (control.getLow() != graphics.lower_ctrl_limit) {
+                control.setLow(graphics.lower_ctrl_limit);
+                changed = true;
+            }
         }
-        PVControl pvControl;
-        pvControl.attach(pvStructure->getSubFieldT(controlString));
-        pvControl.set(control);
+        if (changed) {
+            pvControl.set(control);
+            if (bitSet.get())
+                bitSet->set(controlField->getFieldOffset());
+        }
     }
     if(propertyMask&valueAlarmBit) {
         struct rset *prset = dbGetRset(&dbAddr);
@@ -460,31 +510,52 @@ void  DbUtil::getPropertyData(
             cc(&dbAddr,&ald);
         }
         PVStructurePtr pvAlarmLimits =
-                pvStructure->getSubField<PVStructure>(valueAlarmString);
+                pvStructure->getSubFieldT<PVStructure>(valueAlarmString);
         PVBooleanPtr pvActive = pvAlarmLimits->getSubField<PVBoolean>("active");
         if(pvActive.get()!=NULL) pvActive->put(false);
-        PVFieldPtr pvf = pvAlarmLimits->getSubField(lowAlarmLimitString);
-        if(pvf.get()!=NULL && pvf->getField()->getType()==scalar) {
-            PVScalarPtr pvScalar = static_pointer_cast<PVScalar>(pvf);
-            getConvert()->fromDouble(pvScalar,ald.lower_alarm_limit);
+        PVScalarPtr pvScalar = pvAlarmLimits->getSubField<PVScalar>(lowAlarmLimitString);
+        if(pvScalar.get()!=NULL) {
+            double lowerAlarmLimit = getConvert()->toDouble(pvScalar);
+            if (lowerAlarmLimit != ald.lower_alarm_limit)
+            {
+                getConvert()->fromDouble(pvScalar,ald.lower_alarm_limit);
+                if (bitSet.get())
+                    bitSet->set(pvScalar->getFieldOffset());
+            }
         }
-        pvf = pvAlarmLimits->getSubField(lowWarningLimitString);
-        if(pvf.get()!=NULL && pvf->getField()->getType()==scalar) {
-            PVScalarPtr pvScalar = static_pointer_cast<PVScalar>(pvf);
-            getConvert()->fromDouble(pvScalar,ald.lower_warning_limit);
+        pvScalar = pvAlarmLimits->getSubField<PVScalar>(lowWarningLimitString);
+        if(pvScalar.get()!=NULL) {
+            double lowerWarningLimit = getConvert()->toDouble(pvScalar);
+            if (lowerWarningLimit != ald.lower_warning_limit)
+            {
+                getConvert()->fromDouble(pvScalar,ald.lower_warning_limit);
+                if (bitSet.get())
+                    bitSet->set(pvScalar->getFieldOffset());
+            }
         }
-        pvf = pvAlarmLimits->getSubField(highWarningLimitString);
-        if(pvf.get()!=NULL && pvf->getField()->getType()==scalar) {
-            PVScalarPtr pvScalar = static_pointer_cast<PVScalar>(pvf);
-            getConvert()->fromDouble(pvScalar,ald.upper_warning_limit);
+        pvScalar = pvAlarmLimits->getSubField<PVScalar>(highWarningLimitString);
+        if(pvScalar.get()!=NULL) {
+            double higherAlarmWarning = getConvert()->toDouble(pvScalar);
+            if (higherAlarmWarning != ald.upper_warning_limit)
+            {
+                getConvert()->fromDouble(pvScalar,ald.upper_warning_limit);
+                if (bitSet.get())
+                    bitSet->set(pvScalar->getFieldOffset());
+            }
         }
-        pvf = pvAlarmLimits->getSubField(highAlarmLimitString);
-        if(pvf.get()!=NULL && pvf->getField()->getType()==scalar) {
-            PVScalarPtr pvScalar = static_pointer_cast<PVScalar>(pvf);
-            getConvert()->fromDouble(pvScalar,ald.upper_alarm_limit);
+        pvScalar = pvAlarmLimits->getSubField<PVScalar>(highAlarmLimitString);
+        if(pvScalar.get()!=NULL) {
+            double higherAlarmLimit = getConvert()->toDouble(pvScalar);
+            if (higherAlarmLimit != ald.upper_alarm_limit)
+            {
+                getConvert()->fromDouble(pvScalar,ald.upper_alarm_limit);
+                if (bitSet.get())
+                    bitSet->set(pvScalar->getFieldOffset());
+            }
         }
     }
 }
+
 
 Status  DbUtil::get(
         Requester::shared_pointer const &requester,
@@ -837,6 +908,9 @@ Status  DbUtil::get(
             bitSet->set(pvField->getFieldOffset());
         }
     }
+    getPropertyDataImpl(requester, propertyMask, dbAddr,
+        pvStructure, bitSet);
+
     return Status::Ok;
 }
 

--- a/src/dbPv/3.14/dbUtil.h
+++ b/src/dbPv/3.14/dbUtil.h
@@ -97,6 +97,12 @@ public:
         DbAddr &dbAddr);
 private:
     DbUtil();
+    void getPropertyDataImpl(
+        epics::pvData::Requester::shared_pointer const &requester,
+        int mask,
+        DbAddr &dbAddr,
+        epics::pvData::PVStructurePtr const &pvStructure,
+        epics::pvData::BitSet::shared_pointer const &bitSet);
     epics::pvData::PVStructurePtr  nullPVStructure;
     std::string recordString;
     std::string processString;

--- a/src/dbPv/3.15/dbPvGet.cpp
+++ b/src/dbPv/3.15/dbPvGet.cpp
@@ -65,10 +65,6 @@ bool DbPvGet::init(PVStructure::shared_pointer const &pvRequest)
                     propertyMask,
                     dbPv->getDbChannel()));
     if (!pvStructure.get()) return false;
-    dbUtil->getPropertyData(channelGetRequester,
-                            propertyMask,
-                            dbPv->getDbChannel(),
-                            pvStructure);
     int numFields = pvStructure->getNumberFields();
     bitSet.reset(new BitSet(numFields));
     if (propertyMask & dbUtil->processBit) {

--- a/src/dbPv/3.15/dbPvMonitor.cpp
+++ b/src/dbPv/3.15/dbPvMonitor.cpp
@@ -108,8 +108,6 @@ bool DbPvMonitor::init(
         elements.push_back(element);
     }
     MonitorElementPtr element = elements[0];
-    dbUtil->getPropertyData(monitorRequester, propertyMask,
-        dbPv->getDbChannel(), element->pvStructurePtr);
     StructureConstPtr saveStructure = element->pvStructurePtr->getStructure();
     if((propertyMask&dbUtil->enumValueBit)!=0) {
         caType = CaEnum;

--- a/src/dbPv/3.15/dbUtil.cpp
+++ b/src/dbPv/3.15/dbUtil.cpp
@@ -415,8 +415,25 @@ void  DbUtil::getPropertyData(
         dbChannel *dbChan,
         PVStructurePtr const &pvStructure)
 {
+    BitSet::shared_pointer bitSet;
+    getPropertyDataImpl(requester, propertyMask,
+        dbChan,pvStructure,bitSet);
+}
+
+void  DbUtil::getPropertyDataImpl(
+        Requester::shared_pointer const &requester,
+        int propertyMask,
+        dbChannel *dbChan,
+        PVStructurePtr const &pvStructure,
+        BitSet::shared_pointer const &bitSet)
+{
     if(propertyMask&displayBit) {
         Display display;
+        PVDisplay pvDisplay;
+        PVStructurePtr displayField = pvStructure->getSubFieldT<PVStructure>(displayString);
+        pvDisplay.attach(displayField);
+        pvDisplay.get(display);
+        bool changed = false;
         char units[DB_UNITS_SIZE];
         units[0] = 0;
         long precision = 0;
@@ -424,36 +441,60 @@ void  DbUtil::getPropertyData(
         if(prset && prset->get_units) {
             get_units gunits;
             gunits = (get_units)(prset->get_units);
-            gunits(&dbChan->addr, units);
-            display.setUnits(units);
+            gunits(&dbChan->addr,units);
+            string unitsString = string(units);
+            if (unitsString != display.getUnits()) {
+                display.setUnits(units);
+                changed = true;
+            }
         }
         if(prset && prset->get_precision) {
             get_precision gprec = (get_precision)(prset->get_precision);
-            gprec(&dbChan->addr, &precision);
+            gprec(&dbChan->addr,&precision);
+            string format;
             if(precision>0) {
                 char fmt[16];
                 sprintf(fmt,"%%.%ldf",precision);
-                display.setFormat(string(fmt));
+                format = string(fmt);
             }
             else {
-                static string defaultFormat("%f");
+                const static string defaultFormat("%f");
+                format = defaultFormat;
                 display.setFormat(defaultFormat);
+            }
+            if (format != display.getFormat()) {
+                display.setFormat(format);
+                changed = true;
             }
         }
         struct dbr_grDouble graphics;
         if(prset && prset->get_graphic_double) {
             get_graphic_double gg =
                     (get_graphic_double)(prset->get_graphic_double);
-            gg(&dbChan->addr, &graphics);
-            display.setHigh(graphics.upper_disp_limit);
-            display.setLow(graphics.lower_disp_limit);
+            gg(&dbChan->addr,&graphics);
+            if (display.getHigh() != graphics.upper_disp_limit) {
+                display.setHigh(graphics.upper_disp_limit);
+                changed = true;
+            }
+            if (display.getLow() != graphics.lower_disp_limit) {
+                display.setLow(graphics.lower_disp_limit);
+                changed = true;
+            }
+            
         }
-        PVDisplay pvDisplay;
-        pvDisplay.attach(pvStructure->getSubFieldT(displayString));
-        pvDisplay.set(display);
+        if (changed) {
+            pvDisplay.set(display);
+            if (bitSet.get())
+                bitSet->set(displayField->getFieldOffset());
+        }
     }
     if(propertyMask&controlBit) {
+        PVControl pvControl;
+        PVStructurePtr controlField = pvStructure->getSubFieldT<PVStructure>(controlString);
+        pvControl.attach(controlField);
         Control control;
+        pvControl.get(control);
+        bool changed = false;
         struct rset *prset = dbGetRset(&dbChan->addr);
         struct dbr_ctrlDouble graphics;
         memset(&graphics,0,sizeof(graphics));
@@ -461,12 +502,20 @@ void  DbUtil::getPropertyData(
             get_control_double cc =
                     (get_control_double)(prset->get_control_double);
             cc(&dbChan->addr, &graphics);
-            control.setHigh(graphics.upper_ctrl_limit);
-            control.setLow(graphics.lower_ctrl_limit);
+            if (control.getHigh() != graphics.upper_ctrl_limit) {
+                control.setHigh(graphics.upper_ctrl_limit);
+                changed = true;
+            }
+            if (control.getLow() != graphics.lower_ctrl_limit) {
+                control.setLow(graphics.lower_ctrl_limit);
+                changed = true;
+            }
         }
-        PVControl pvControl;
-        pvControl.attach(pvStructure->getSubFieldT(controlString));
-        pvControl.set(control);
+        if (changed) {
+            pvControl.set(control);
+            if (bitSet.get())
+                bitSet->set(controlField->getFieldOffset());
+        }
     }
     if(propertyMask&valueAlarmBit) {
         struct rset *prset = dbGetRset(&dbChan->addr);
@@ -475,31 +524,51 @@ void  DbUtil::getPropertyData(
         if(prset && prset->get_alarm_double) {
             get_alarm_double cc =
                     (get_alarm_double)(prset->get_alarm_double);
-            cc(&dbChan->addr, &ald);
+            cc(&dbChan->addr,&ald);
         }
         PVStructurePtr pvAlarmLimits =
-                pvStructure->getSubField<PVStructure>(valueAlarmString);
+                pvStructure->getSubFieldT<PVStructure>(valueAlarmString);
         PVBooleanPtr pvActive = pvAlarmLimits->getSubField<PVBoolean>("active");
         if(pvActive.get()!=NULL) pvActive->put(false);
-        PVFieldPtr pvf = pvAlarmLimits->getSubField(lowAlarmLimitString);
-        if(pvf.get()!=NULL && pvf->getField()->getType()==scalar) {
-            PVScalarPtr pvScalar = static_pointer_cast<PVScalar>(pvf);
-            getConvert()->fromDouble(pvScalar,ald.lower_alarm_limit);
+        PVScalarPtr pvScalar = pvAlarmLimits->getSubField<PVScalar>(lowAlarmLimitString);
+        if(pvScalar.get()!=NULL) {
+            double lowerAlarmLimit = getConvert()->toDouble(pvScalar);
+            if (lowerAlarmLimit != ald.lower_alarm_limit)
+            {
+                getConvert()->fromDouble(pvScalar,ald.lower_alarm_limit);
+                if (bitSet.get())
+                    bitSet->set(pvScalar->getFieldOffset());
+            }
         }
-        pvf = pvAlarmLimits->getSubField(lowWarningLimitString);
-        if(pvf.get()!=NULL && pvf->getField()->getType()==scalar) {
-            PVScalarPtr pvScalar = static_pointer_cast<PVScalar>(pvf);
-            getConvert()->fromDouble(pvScalar,ald.lower_warning_limit);
+        pvScalar = pvAlarmLimits->getSubField<PVScalar>(lowWarningLimitString);
+        if(pvScalar.get()!=NULL) {
+            double lowerWarningLimit = getConvert()->toDouble(pvScalar);
+            if (lowerWarningLimit != ald.lower_warning_limit)
+            {
+                getConvert()->fromDouble(pvScalar,ald.lower_warning_limit);
+                if (bitSet.get())
+                    bitSet->set(pvScalar->getFieldOffset());
+            }
         }
-        pvf = pvAlarmLimits->getSubField(highWarningLimitString);
-        if(pvf.get()!=NULL && pvf->getField()->getType()==scalar) {
-            PVScalarPtr pvScalar = static_pointer_cast<PVScalar>(pvf);
-            getConvert()->fromDouble(pvScalar,ald.upper_warning_limit);
+        pvScalar = pvAlarmLimits->getSubField<PVScalar>(highWarningLimitString);
+        if(pvScalar.get()!=NULL) {
+            double higherAlarmWarning = getConvert()->toDouble(pvScalar);
+            if (higherAlarmWarning != ald.upper_warning_limit)
+            {
+                getConvert()->fromDouble(pvScalar,ald.upper_warning_limit);
+                if (bitSet.get())
+                    bitSet->set(pvScalar->getFieldOffset());
+            }
         }
-        pvf = pvAlarmLimits->getSubField(highAlarmLimitString);
-        if(pvf.get()!=NULL && pvf->getField()->getType()==scalar) {
-            PVScalarPtr pvScalar = static_pointer_cast<PVScalar>(pvf);
-            getConvert()->fromDouble(pvScalar,ald.upper_alarm_limit);
+        pvScalar = pvAlarmLimits->getSubField<PVScalar>(highAlarmLimitString);
+        if(pvScalar.get()!=NULL) {
+            double higherAlarmLimit = getConvert()->toDouble(pvScalar);
+            if (higherAlarmLimit != ald.upper_alarm_limit)
+            {
+                getConvert()->fromDouble(pvScalar,ald.upper_alarm_limit);
+                if (bitSet.get())
+                    bitSet->set(pvScalar->getFieldOffset());
+            }
         }
     }
 }
@@ -856,6 +925,10 @@ Status  DbUtil::get(
             bitSet->set(pvField->getFieldOffset());
         }
     }
+
+    //getPropertyDataImpl(requester, propertyMask, dbChan,
+    //    pvStructure, bitSet);
+
     return Status::Ok;
 }
 

--- a/src/dbPv/3.15/dbUtil.h
+++ b/src/dbPv/3.15/dbUtil.h
@@ -97,6 +97,12 @@ public:
         dbChannel *dbChan);
 private:
     DbUtil();
+    void getPropertyDataImpl(
+        epics::pvData::Requester::shared_pointer const &requester,
+        int mask,
+        dbChannel *dbChan,
+        epics::pvData::PVStructurePtr const &pvStructure,
+        epics::pvData::BitSet::shared_pointer const &bitSet);
     epics::pvData::PVStructurePtr  nullPVStructure;
     std::string recordString;
     std::string processString;


### PR DESCRIPTION
Set display, control, valueAlarm on all gets/monitor updates (not just initial ones). Add version of getProperty data to take a bitset and implement old version using this. Set property data in DBUtil::get(). Remove redundant calls setting property data initially in gets/monitors.

Fixes #48.