### PR TITLE
Fix issues #3 and #5

### DIFF
--- a/src/dbPv/3.14/dbPvGet.cpp
+++ b/src/dbPv/3.14/dbPvGet.cpp
@@ -65,7 +65,8 @@ bool DbPvGet::init(PVStructure::shared_pointer const &pvRequest)
                 dbUtil->createPVStructure(
                     channelGetRequester,
                     propertyMask,
-                    dbAddr));
+                    dbAddr,
+                    pvRequest));
     if (!pvStructure.get()) return false;
     int numFields = pvStructure->getNumberFields();
     bitSet.reset(new BitSet(numFields));

--- a/src/dbPv/3.14/dbPvMonitor.cpp
+++ b/src/dbPv/3.14/dbPvMonitor.cpp
@@ -104,7 +104,8 @@ bool DbPvMonitor::init(
         PVStructurePtr pvStructure(dbUtil->createPVStructure(
                 monitorRequester,
                 propertyMask,
-                dbAddr));
+                dbAddr,
+                pvRequest));
         if(!pvStructure) return false;
         MonitorElementPtr element(new MonitorElement(pvStructure));
         elements.push_back(element);

--- a/src/dbPv/3.14/dbPvPut.cpp
+++ b/src/dbPv/3.14/dbPvPut.cpp
@@ -76,7 +76,8 @@ bool DbPvPut::init(PVStructure::shared_pointer const &pvRequest)
         dbUtil->createPVStructure(
             channelPutRequester,
             propertyMask,
-            dbAddr));
+            dbAddr,
+            pvRequest));
     if (!pvStructure.get()) return false;
     if (propertyMask & dbUtil->dbPutBit) {
         if (propertyMask & dbUtil->processBit) {

--- a/src/dbPv/3.14/dbUtil.cpp
+++ b/src/dbPv/3.14/dbUtil.cpp
@@ -465,6 +465,24 @@ void  DbUtil::getPropertyData(
         PVStructurePtr const &pvStructure,
         BitSet::shared_pointer const &bitSet)
 {
+        getDisplayData(requester, propertyMask, dbAddr,
+            pvStructure, bitSet);
+
+        getControlData(requester, propertyMask, dbAddr,
+            pvStructure, bitSet);
+
+        getValueAlarmData(requester, propertyMask, dbAddr,
+            pvStructure, bitSet);
+}
+
+void  DbUtil::getDisplayData(
+        Requester::shared_pointer const &requester,
+        int propertyMask,
+        DbAddr &dbAddr,
+        PVStructurePtr const &pvStructure,
+        BitSet::shared_pointer const &bitSet)
+{
+
     if(propertyMask&displayBit) {
         PVStructurePtr displayField = pvStructure->getSubFieldT<PVStructure>(displayString);
         char units[DB_UNITS_SIZE];
@@ -529,6 +547,15 @@ void  DbUtil::getPropertyData(
             }
         }
     }
+}
+
+void  DbUtil::getControlData(
+        Requester::shared_pointer const &requester,
+        int propertyMask,
+        DbAddr &dbAddr,
+        PVStructurePtr const &pvStructure,
+        BitSet::shared_pointer const &bitSet)
+{
     if(propertyMask&controlBit) {
         PVStructurePtr controlField = pvStructure->getSubFieldT<PVStructure>(controlString);
         struct rset *prset = dbGetRset(&dbAddr);
@@ -556,6 +583,15 @@ void  DbUtil::getPropertyData(
             }
         }
     }
+}
+
+void  DbUtil::getValueAlarmData(
+        Requester::shared_pointer const &requester,
+        int propertyMask,
+        DbAddr &dbAddr,
+        PVStructurePtr const &pvStructure,
+        BitSet::shared_pointer const &bitSet)
+{
     if(propertyMask&valueAlarmBit) {
         struct rset *prset = dbGetRset(&dbAddr);
         struct dbr_alDouble ald;

--- a/src/dbPv/3.14/dbUtil.cpp
+++ b/src/dbPv/3.14/dbUtil.cpp
@@ -44,6 +44,52 @@ using epics::pvAccess::ca::dbrStatus2alarmStatus;
 
 namespace epics { namespace pvaSrv { 
 
+// Filter out unrequested fields from a source structure according to a
+// structure conforming to the format of the "field" field of a pvRequest,
+// preserving type ids of unchanged structures.
+static StructureConstPtr refineStructure(StructureConstPtr const & source,
+           StructureConstPtr const & requestedFields)
+{
+    if (requestedFields.get() == NULL || requestedFields->getNumberFields() == 0)
+        return source;
+
+    FieldBuilderPtr builder = getFieldCreate()->createFieldBuilder();
+    boolean addId = true;
+
+    FieldConstPtrArray fields = source->getFields();
+    StringArray names = source->getFieldNames();
+    size_t i = 0;
+    for (FieldConstPtrArray::const_iterator it = fields.begin(); it != fields.end(); ++it)
+    {
+        FieldConstPtr field = *it;
+        const std::string & name = names[i++];
+        FieldConstPtr reqField = requestedFields->getField(name);
+        if (reqField.get())
+        {
+            if (field->getType() != structure || (reqField->getType() != structure))
+                builder->add(name,field);
+            else
+            {
+                StructureConstPtr substruct =
+                    std::tr1::dynamic_pointer_cast<const Structure>(field);
+
+                StructureConstPtr reqSubstruct =
+                    std::tr1::dynamic_pointer_cast<const Structure>(reqField);
+
+                StructureConstPtr nested = refineStructure(substruct, reqSubstruct);
+                builder->add(name,nested);
+                if (nested->getID() != substruct->getID())
+                    addId = false;
+            }
+        }
+        else
+            addId =  false;
+    }
+    if (addId)
+        builder->setId(source->getID());
+    return  builder->createStructure();
+}
+
 DbUtilPtr DbUtil::getDbUtil()
 {
     static DbUtilPtr util;
@@ -273,7 +319,6 @@ int DbUtil::getProperties(
         default:
             break;
         }
-
     }
     if(propertyMask&enumValueBit) {
         pvField = pvRequest->getSubField(valueIndexString);
@@ -283,7 +328,8 @@ int DbUtil::getProperties(
 }
 
 PVStructurePtr DbUtil::createPVStructure(
-        Requester::shared_pointer const &requester,int propertyMask,DbAddr &dbAddr)
+    Requester::shared_pointer const &requester,int propertyMask,
+    DbAddr &dbAddr, PVStructure::shared_pointer const &pvRequest)
 {
     StandardPVFieldPtr standardPVField = getStandardPVField();
     StandardFieldPtr standardField = getStandardField();
@@ -309,15 +355,15 @@ PVStructurePtr DbUtil::createPVStructure(
         properties += valueAlarmString;
     }
 
-    StructureConstPtr structure;
+    StructureConstPtr unrefinedStructure;
 
     if((propertyMask & enumValueBit)!=0) {
         if((propertyMask&enumIndexBit)!=0)
             // TODO: This is the wrong structure. Leave now until
             // have fix for returning partial structures
-            structure = standardField->scalar(pvInt,properties);
+            unrefinedStructure = standardField->scalar(pvInt,properties);
         else
-            structure = standardField->enumerated(properties);
+            unrefinedStructure = standardField->enumerated(properties);
     }
     else {
         ScalarType scalarType = propertyMask&isLinkBit ?
@@ -326,17 +372,17 @@ PVStructurePtr DbUtil::createPVStructure(
             throw std::logic_error("Should never get here");
 
         if((propertyMask & scalarValueBit)!=0)
-            structure = standardField->scalar(scalarType,properties);
+            unrefinedStructure = standardField->scalar(scalarType,properties);
         else if((propertyMask & arrayValueBit)!=0)
-            structure = standardField->scalarArray(scalarType,properties);
+            unrefinedStructure = standardField->scalarArray(scalarType,properties);
         else
             return nullPVStructure;
     }
 
     // delete value field if not requested
     if(!(propertyMask&getValueBit)) {
-        FieldConstPtrArray fields = structure->getFields();
-        StringArray names = structure->getFieldNames();
+        FieldConstPtrArray fields = unrefinedStructure->getFields();
+        StringArray names = unrefinedStructure->getFieldNames();
         for(size_t i=0; i<names.size(); ++i) {
             if(names[i].compare("value")==0) {
                 fields.erase(fields.begin()+i);
@@ -344,10 +390,19 @@ PVStructurePtr DbUtil::createPVStructure(
                 break;
             }
         }
-        structure = fieldCreate->createStructure(names,fields);
+        unrefinedStructure = fieldCreate->createStructure(names,fields);
     }
 
-    PVStructurePtr pvStructure = pvDataCreate->createPVStructure(structure);
+    PVStructurePtr fieldPVStructure = pvRequest->getSubField<PVStructure>("field");
+    // Don't refine structure for enum types yet, not until correct
+    // handling for value.index is implemented
+    bool refine = fieldPVStructure.get() && (propertyMask&enumValueBit) == 0;
+
+    StructureConstPtr finalStructure = refine ?
+        refineStructure(unrefinedStructure, fieldPVStructure->getStructure()) :
+        unrefinedStructure;
+
+    PVStructurePtr pvStructure = pvDataCreate->createPVStructure(finalStructure);
 
     if((propertyMask&enumValueBit)!=0) {
         struct dbr_enumStrs enumStrs;
@@ -403,58 +458,60 @@ PVStructurePtr DbUtil::createPVStructure(
 
 void  DbUtil::getPropertyData(
         Requester::shared_pointer const &requester,
-        int propertyMask,DbAddr &dbAddr,
+        int propertyMask,
+        DbAddr &dbAddr,
         PVStructurePtr const &pvStructure)
 {
     BitSet::shared_pointer bitSet;
-    getPropertyDataImpl(requester, propertyMask, dbAddr,
+    getPropertyData(requester, propertyMask, dbAddr,
         pvStructure, bitSet);
 }
 
-void  DbUtil::getPropertyDataImpl(
+void  DbUtil::getPropertyData(
         Requester::shared_pointer const &requester,
         int propertyMask,DbAddr &dbAddr,
         PVStructurePtr const &pvStructure,
         BitSet::shared_pointer const &bitSet)
 {
     if(propertyMask&displayBit) {
-        Display display;
-        PVDisplay pvDisplay;
         PVStructurePtr displayField = pvStructure->getSubFieldT<PVStructure>(displayString);
-        pvDisplay.attach(displayField);
-        pvDisplay.get(display);
-        bool changed = false;
         char units[DB_UNITS_SIZE];
         units[0] = 0;
         long precision = 0;
         struct rset *prset = dbGetRset(&dbAddr);
         if(prset && prset->get_units) {
-            get_units gunits;
-            gunits = (get_units)(prset->get_units);
-            gunits(&dbAddr,units);
-            string unitsString = string(units);
-            if (unitsString != display.getUnits()) {
-                display.setUnits(units);
-                changed = true;
+            PVStringPtr unitsField = displayField->getSubField<PVString>("units");
+            if (unitsField.get()) {
+                get_units gunits;
+                gunits = (get_units)(prset->get_units);
+                gunits(&dbAddr,units);
+                string unitsString = string(units);
+                if (unitsString != unitsField->get()) {
+                    unitsField->put(unitsString);
+                    if (bitSet.get()) 
+                        bitSet->set(unitsField->getFieldOffset());
+                }
             }
         }
         if(prset && prset->get_precision) {
-            get_precision gprec = (get_precision)(prset->get_precision);
-            gprec(&dbAddr,&precision);
-            string format;
-            if(precision>0) {
-                char fmt[16];
-                sprintf(fmt,"%%.%ldf",precision);
-                format = string(fmt);
-            }
-            else {
-                const static string defaultFormat("%f");
-                format = defaultFormat;
-                display.setFormat(defaultFormat);
-            }
-            if (format != display.getFormat()) {
-                display.setFormat(format);
-                changed = true;
+            PVStringPtr formatField = displayField->getSubField<PVString>("format");
+            if (formatField.get()) {
+                get_precision gprec = (get_precision)(prset->get_precision);
+                gprec(&dbAddr,&precision);
+                string format;
+                if(precision>0) {
+                    char fmt[16];
+                    sprintf(fmt,"%%.%ldf",precision);
+                    format = string(fmt);
+                } else {
+                    const static string defaultFormat("%f");
+                    format = defaultFormat;
+                }
+                if (format != formatField->get()) {
+                    formatField->put(format);
+                    if (bitSet.get()) 
+                       bitSet->set(formatField->getFieldOffset());
+                }
             }
         }
         struct dbr_grDouble graphics;
@@ -462,31 +519,26 @@ void  DbUtil::getPropertyDataImpl(
             get_graphic_double gg =
                     (get_graphic_double)(prset->get_graphic_double);
             gg(&dbAddr,&graphics);
-            if (display.getHigh() != graphics.upper_disp_limit) {
-                display.setHigh(graphics.upper_disp_limit);
-                changed = true;
+
+            PVDoublePtr limitLowField = displayField->getSubField<PVDouble>("limitLow");
+            if (limitLowField.get() &&
+                    limitLowField->get() != graphics.lower_disp_limit) {
+                limitLowField->put(graphics.lower_disp_limit);
+                if (bitSet.get()) 
+                    bitSet->set(limitLowField->getFieldOffset());
             }
-            if (display.getLow() != graphics.lower_disp_limit) {
-                display.setLow(graphics.lower_disp_limit);
-                changed = true;
+
+            PVDoublePtr limitHighField = displayField->getSubField<PVDouble>("limitHigh");
+            if (limitHighField.get() &&
+                    limitHighField->get() != graphics.upper_disp_limit) {
+                limitHighField->put(graphics.upper_disp_limit);
+                if (bitSet.get()) 
+                    bitSet->set(limitHighField->getFieldOffset());
             }
-            
-        }
-        if (changed) {
-            pvDisplay.set(display);
-            if (bitSet.get()) 
-                bitSet->set(displayField->getFieldOffset());
-            else
-                std::cout << "display: bitset == null" << std::endl;
         }
     }
     if(propertyMask&controlBit) {
-        PVControl pvControl;
         PVStructurePtr controlField = pvStructure->getSubFieldT<PVStructure>(controlString);
-        pvControl.attach(controlField);
-        Control control;
-        pvControl.get(control);
-        bool changed = false;
         struct rset *prset = dbGetRset(&dbAddr);
         struct dbr_ctrlDouble graphics;
         memset(&graphics,0,sizeof(graphics));
@@ -494,19 +546,22 @@ void  DbUtil::getPropertyDataImpl(
             get_control_double cc =
                     (get_control_double)(prset->get_control_double);
             cc(&dbAddr, &graphics);
-            if (control.getHigh() != graphics.upper_ctrl_limit) {
-                control.setHigh(graphics.upper_ctrl_limit);
-                changed = true;
+
+            PVDoublePtr limitLowField = controlField->getSubField<PVDouble>("limitLow");
+            if (limitLowField.get() &&
+                    limitLowField->get() != graphics.lower_ctrl_limit) {
+                limitLowField->put(graphics.lower_ctrl_limit);
+                if (bitSet.get()) 
+                    bitSet->set(limitLowField->getFieldOffset());
             }
-            if (control.getLow() != graphics.lower_ctrl_limit) {
-                control.setLow(graphics.lower_ctrl_limit);
-                changed = true;
+
+            PVDoublePtr limitHighField = controlField->getSubField<PVDouble>("limitHigh");
+            if (limitHighField.get() &&
+                    limitHighField->get() != graphics.upper_ctrl_limit) {
+                limitHighField->put(graphics.upper_ctrl_limit);
+                if (bitSet.get()) 
+                    bitSet->set(limitHighField->getFieldOffset());
             }
-        }
-        if (changed) {
-            pvControl.set(control);
-            if (bitSet.get())
-                bitSet->set(controlField->getFieldOffset());
         }
     }
     if(propertyMask&valueAlarmBit) {
@@ -565,10 +620,10 @@ void  DbUtil::getPropertyDataImpl(
     }
 }
 
-
 Status  DbUtil::get(
         Requester::shared_pointer const &requester,
-        int propertyMask,DbAddr &dbAddr,
+        int propertyMask,
+        DbAddr &dbAddr,
         PVStructurePtr const &pvStructure,
         BitSet::shared_pointer const &bitSet,
         CaData *caData)
@@ -854,41 +909,37 @@ Status  DbUtil::get(
             }
         }
     }
-    if((propertyMask&timeStampBit)!=0) {
-        TimeStamp timeStamp;
-        PVTimeStamp pvTimeStamp;
-        PVFieldPtr pvField = pvStructure->getSubFieldT(timeStampString);
-        if(!pvTimeStamp.attach(pvField)) {
-            throw std::logic_error("V3ChannelGet::get logic error");
-        }
+
+    if((propertyMask&timeStampBit)!=0)
+    {
+        PVStructurePtr pvField = pvStructure->getSubFieldT<PVStructure>(timeStampString);
         epicsTimeStamp *epicsTimeStamp;
         struct dbCommon *precord = dbAddr.precord;
         if(caData) {
             epicsTimeStamp = &caData->timeStamp;
         } else {
-            epicsTimeStamp = &precord->time;
+                epicsTimeStamp = &precord->time;     
         }
-        epicsUInt32 secPastEpoch = epicsTimeStamp->secPastEpoch;
-        epicsUInt32 nsec = epicsTimeStamp->nsec;
-        int64 seconds = secPastEpoch;
-        seconds += POSIX_TIME_AT_EPICS_EPOCH;
-        int32 nanoseconds = nsec;
-        pvTimeStamp.get(timeStamp);
-        int64 oldSecs = timeStamp.getSecondsPastEpoch();
-        int32 oldNano = timeStamp.getNanoseconds();
-        if(oldSecs!=seconds || oldNano!=nanoseconds) {
-            timeStamp.put(seconds,nanoseconds);
-            pvTimeStamp.set(timeStamp);
-            bitSet->set(pvField->getFieldOffset());
+        PVLongPtr pvSecs = pvField->getSubField<PVLong>("secondsPastEpoch");
+        if (pvSecs.get()) {
+            int64 seconds  = epicsTimeStamp->secPastEpoch + POSIX_TIME_AT_EPICS_EPOCH;
+            if(seconds != pvSecs->get()) {
+                pvSecs->put(seconds);
+                bitSet->set(pvSecs->getFieldOffset());
+            }
+        }
+        PVIntPtr pvNsecs = pvField->getSubField<PVInt>("nanoseconds");
+        if (pvNsecs.get()) {
+            int32 nanoseconds= epicsTimeStamp->nsec;
+            if(nanoseconds != pvNsecs->get()) {
+                pvNsecs->put(nanoseconds);
+                bitSet->set(pvNsecs->getFieldOffset());
+            }
         }
     }
+
     if((propertyMask&alarmBit)!=0) {
-        Alarm alarm;
-        PVAlarm pvAlarm;
-        PVFieldPtr pvField = pvStructure->getSubFieldT(alarmString);
-        if(!pvAlarm.attach(pvField)) {
-            throw std::logic_error("V3ChannelGet::get logic error");
-        }
+        PVStructurePtr pvField = pvStructure->getSubFieldT<PVStructure>(alarmString);
         struct dbCommon *precord = dbAddr.precord;
         string message;
         epicsEnum16 stat;
@@ -902,22 +953,27 @@ Status  DbUtil::get(
             stat = dbrStatus2alarmStatus[precord->stat];
             sevr = precord->sevr;
         }
-        pvAlarm.get(alarm);
-        AlarmSeverity alarmSeverity = alarm.getSeverity();
-        epicsEnum16 prevSeverity = static_cast<epicsEnum16>(alarmSeverity);
-        AlarmStatus alarmStatus = alarm.getStatus();
-        epicsEnum16 prevStatus = static_cast<epicsEnum16>(alarmStatus);
-        if((prevSeverity!=sevr) || (prevStatus!=stat)) {
-            AlarmSeverity severity = static_cast<AlarmSeverity>(sevr);
-            alarm.setSeverity(severity);
-            AlarmStatus status = static_cast<AlarmStatus>(stat);
-            alarm.setStatus(status);
-            alarm.setMessage(message);
-            pvAlarm.set(alarm);
-            bitSet->set(pvField->getFieldOffset());
+
+        PVIntPtr pvStatus = pvField->getSubField<PVInt>("status");
+        if (pvStatus.get() && stat != pvStatus->get()) {
+            pvStatus->put(stat);
+            bitSet->set(pvStatus->getFieldOffset());
+        }
+
+        PVIntPtr pvSeverity = pvField->getSubField<PVInt>("severity");
+        if (pvSeverity.get() && sevr != pvSeverity->get()) {
+            pvSeverity->put(sevr);
+            bitSet->set(pvSeverity->getFieldOffset());
+        }
+
+        PVStringPtr pvMessage = pvField->getSubField<PVString>("message");
+        if (pvMessage.get() && message != pvMessage->get()) {
+            pvMessage->put(message);
+            bitSet->set(pvMessage->getFieldOffset());
         }
     }
-    getPropertyDataImpl(requester, propertyMask, dbAddr,
+
+    getPropertyData(requester, propertyMask, dbAddr,
         pvStructure, bitSet);
 
     return Status::Ok;

--- a/src/dbPv/3.14/dbUtil.cpp
+++ b/src/dbPv/3.14/dbUtil.cpp
@@ -375,20 +375,6 @@ PVStructurePtr DbUtil::createPVStructure(
             return nullPVStructure;
     }
 
-    // delete value field if not requested
-    if(!(propertyMask&getValueBit)) {
-        FieldConstPtrArray fields = unrefinedStructure->getFields();
-        StringArray names = unrefinedStructure->getFieldNames();
-        for(size_t i=0; i<names.size(); ++i) {
-            if(names[i].compare("value")==0) {
-                fields.erase(fields.begin()+i);
-                names.erase(names.begin()+i);
-                break;
-            }
-        }
-        unrefinedStructure = fieldCreate->createStructure(names,fields);
-    }
-
     PVStructurePtr fieldPVStructure = pvRequest->getSubField<PVStructure>("field");
     StructureConstPtr finalStructure = fieldPVStructure.get() ?
         refineStructure(unrefinedStructure, fieldPVStructure->getStructure()) :

--- a/src/dbPv/3.14/dbUtil.h
+++ b/src/dbPv/3.14/dbUtil.h
@@ -124,6 +124,7 @@ private:
     std::string highAlarmLimitString;
     std::string allString;
     std::string indexString;
+    std::string choicesString;
 };
 
 }}

--- a/src/dbPv/3.14/dbUtil.h
+++ b/src/dbPv/3.14/dbUtil.h
@@ -98,12 +98,35 @@ public:
         DbAddr &dbAddr);
 private:
     DbUtil();
+
     void getPropertyData(
         epics::pvData::Requester::shared_pointer const &requester,
         int mask,
         DbAddr &dbAddr,
         epics::pvData::PVStructurePtr const &pvStructure,
         epics::pvData::BitSet::shared_pointer const &bitSet);
+
+    void getDisplayData(
+        epics::pvData::Requester::shared_pointer const &requester,
+        int mask,
+        DbAddr &dbAddr,
+        epics::pvData::PVStructurePtr const &pvStructure,
+        epics::pvData::BitSet::shared_pointer const &bitSet);
+
+    void getControlData(
+        epics::pvData::Requester::shared_pointer const &requester,
+        int mask,
+        DbAddr &dbAddr,
+        epics::pvData::PVStructurePtr const &pvStructure,
+        epics::pvData::BitSet::shared_pointer const &bitSet);
+
+    void getValueAlarmData(
+        epics::pvData::Requester::shared_pointer const &requester,
+        int mask,
+        DbAddr &dbAddr,
+        epics::pvData::PVStructurePtr const &pvStructure,
+        epics::pvData::BitSet::shared_pointer const &bitSet);
+
     epics::pvData::PVStructurePtr  nullPVStructure;
     std::string recordString;
     std::string processString;

--- a/src/dbPv/3.14/dbUtil.h
+++ b/src/dbPv/3.14/dbUtil.h
@@ -73,7 +73,8 @@ public:
         bool processDefault);
     epics::pvData::PVStructurePtr createPVStructure(
         epics::pvData::Requester::shared_pointer const &requester,
-        int mask,DbAddr &dbAddr);
+        int mask,DbAddr &dbAddr,
+        epics::pvData::PVStructure::shared_pointer const &pvRequest);
     void getPropertyData(
         epics::pvData::Requester::shared_pointer const &requester,
         int mask,DbAddr &dbAddr,
@@ -97,7 +98,7 @@ public:
         DbAddr &dbAddr);
 private:
     DbUtil();
-    void getPropertyDataImpl(
+    void getPropertyData(
         epics::pvData::Requester::shared_pointer const &requester,
         int mask,
         DbAddr &dbAddr,

--- a/src/dbPv/3.15/dbPvGet.cpp
+++ b/src/dbPv/3.15/dbPvGet.cpp
@@ -63,7 +63,8 @@ bool DbPvGet::init(PVStructure::shared_pointer const &pvRequest)
                 dbUtil->createPVStructure(
                     channelGetRequester,
                     propertyMask,
-                    dbPv->getDbChannel()));
+                    dbPv->getDbChannel(),
+                    pvRequest));
     if (!pvStructure.get()) return false;
     int numFields = pvStructure->getNumberFields();
     bitSet.reset(new BitSet(numFields));

--- a/src/dbPv/3.15/dbPvMonitor.cpp
+++ b/src/dbPv/3.15/dbPvMonitor.cpp
@@ -102,7 +102,8 @@ bool DbPvMonitor::init(
         PVStructurePtr pvStructure(dbUtil->createPVStructure(
                 monitorRequester,
                 propertyMask,
-                dbPv->getDbChannel()));
+                dbPv->getDbChannel(),
+                pvRequest));
         if(!pvStructure) return false;
         MonitorElementPtr element(new MonitorElement(pvStructure));
         elements.push_back(element);

--- a/src/dbPv/3.15/dbPvPut.cpp
+++ b/src/dbPv/3.15/dbPvPut.cpp
@@ -75,7 +75,8 @@ bool DbPvPut::init(PVStructure::shared_pointer const &pvRequest)
         dbUtil->createPVStructure(
             channelPutRequester,
             propertyMask,
-            dbPv->getDbChannel()));
+            dbPv->getDbChannel(),
+            pvRequest));
     if (!pvStructure.get()) return false;
     if (propertyMask & dbUtil->dbPutBit) {
         if (propertyMask & dbUtil->processBit) {

--- a/src/dbPv/3.15/dbUtil.cpp
+++ b/src/dbPv/3.15/dbUtil.cpp
@@ -934,8 +934,8 @@ Status  DbUtil::get(
         }
     }
 
-    //getPropertyDataImpl(requester, propertyMask, dbChan,
-    //    pvStructure, bitSet);
+    getPropertyDataImpl(requester, propertyMask, dbChan,
+        pvStructure, bitSet);
 
     return Status::Ok;
 }

--- a/src/dbPv/3.15/dbUtil.cpp
+++ b/src/dbPv/3.15/dbUtil.cpp
@@ -390,20 +390,6 @@ PVStructurePtr DbUtil::createPVStructure(
             return nullPVStructure;
     }
 
-    // delete value field if not requested
-    if(!(propertyMask&getValueBit)) {
-        FieldConstPtrArray fields = unrefinedStructure->getFields();
-        StringArray names = unrefinedStructure->getFieldNames();
-        for(size_t i=0; i<names.size(); ++i) {
-            if(names[i].compare("value")==0) {
-                fields.erase(fields.begin()+i);
-                names.erase(names.begin()+i);
-                break;
-            }
-        }
-        unrefinedStructure = fieldCreate->createStructure(names,fields);
-    }
-
     PVStructurePtr fieldPVStructure = pvRequest->getSubField<PVStructure>("field"); 
     StructureConstPtr finalStructure = fieldPVStructure.get() ?
         refineStructure(unrefinedStructure, fieldPVStructure->getStructure()) :

--- a/src/dbPv/3.15/dbUtil.cpp
+++ b/src/dbPv/3.15/dbUtil.cpp
@@ -482,6 +482,24 @@ void  DbUtil::getPropertyData(
         PVStructurePtr const &pvStructure,
         BitSet::shared_pointer const &bitSet)
 {
+        getDisplayData(requester, propertyMask, dbChan,
+            pvStructure, bitSet);
+
+        getControlData(requester, propertyMask, dbChan,
+            pvStructure, bitSet);
+
+        getValueAlarmData(requester, propertyMask, dbChan,
+            pvStructure, bitSet);
+}
+
+void  DbUtil::getDisplayData(
+        Requester::shared_pointer const &requester,
+        int propertyMask,
+        dbChannel *dbChan,
+        PVStructurePtr const &pvStructure,
+        BitSet::shared_pointer const &bitSet)
+{
+
     if(propertyMask&displayBit) {
         PVStructurePtr displayField = pvStructure->getSubFieldT<PVStructure>(displayString);
         char units[DB_UNITS_SIZE];
@@ -546,6 +564,15 @@ void  DbUtil::getPropertyData(
             }
         }
     }
+}
+
+void  DbUtil::getControlData(
+        Requester::shared_pointer const &requester,
+        int propertyMask,
+        dbChannel *dbChan,
+        PVStructurePtr const &pvStructure,
+        BitSet::shared_pointer const &bitSet)
+{
     if(propertyMask&controlBit) {
         PVStructurePtr controlField = pvStructure->getSubFieldT<PVStructure>(controlString);
         struct rset *prset = dbGetRset(&dbChan->addr);
@@ -573,6 +600,15 @@ void  DbUtil::getPropertyData(
             }
         }
     }
+}
+
+void  DbUtil::getValueAlarmData(
+        Requester::shared_pointer const &requester,
+        int propertyMask,
+        dbChannel *dbChan,
+        PVStructurePtr const &pvStructure,
+        BitSet::shared_pointer const &bitSet)
+{
     if(propertyMask&valueAlarmBit) {
         struct rset *prset = dbGetRset(&dbChan->addr);
         struct dbr_alDouble ald;

--- a/src/dbPv/3.15/dbUtil.h
+++ b/src/dbPv/3.15/dbUtil.h
@@ -124,6 +124,7 @@ private:
     std::string highAlarmLimitString;
     std::string allString;
     std::string indexString;
+    std::string choicesString;
 };
 
 }}

--- a/src/dbPv/3.15/dbUtil.h
+++ b/src/dbPv/3.15/dbUtil.h
@@ -98,12 +98,35 @@ public:
         dbChannel *dbChan);
 private:
     DbUtil();
+
     void getPropertyData(
         epics::pvData::Requester::shared_pointer const &requester,
         int mask,
         dbChannel *dbChan,
         epics::pvData::PVStructurePtr const &pvStructure,
         epics::pvData::BitSet::shared_pointer const &bitSet);
+
+    void getDisplayData(
+        epics::pvData::Requester::shared_pointer const &requester,
+        int mask,
+        dbChannel *dbChan,
+        epics::pvData::PVStructurePtr const &pvStructure,
+        epics::pvData::BitSet::shared_pointer const &bitSet);
+
+    void getControlData(
+        epics::pvData::Requester::shared_pointer const &requester,
+        int mask,
+        dbChannel *dbChan,
+        epics::pvData::PVStructurePtr const &pvStructure,
+        epics::pvData::BitSet::shared_pointer const &bitSet);
+
+    void getValueAlarmData(
+        epics::pvData::Requester::shared_pointer const &requester,
+        int mask,
+        dbChannel *dbChan,
+        epics::pvData::PVStructurePtr const &pvStructure,
+        epics::pvData::BitSet::shared_pointer const &bitSet);
+
     epics::pvData::PVStructurePtr  nullPVStructure;
     std::string recordString;
     std::string processString;

--- a/src/dbPv/3.15/dbUtil.h
+++ b/src/dbPv/3.15/dbUtil.h
@@ -73,7 +73,8 @@ public:
         bool processDefault);
     epics::pvData::PVStructurePtr createPVStructure(
         epics::pvData::Requester::shared_pointer const &requester,
-        int mask, dbChannel *dbChan);
+        int mask, dbChannel *dbChan,
+        epics::pvData::PVStructure::shared_pointer const &pvRequest);
     void getPropertyData(
         epics::pvData::Requester::shared_pointer const &requester,
         int mask, dbChannel *dbChan,
@@ -97,7 +98,7 @@ public:
         dbChannel *dbChan);
 private:
     DbUtil();
-    void getPropertyDataImpl(
+    void getPropertyData(
         epics::pvData::Requester::shared_pointer const &requester,
         int mask,
         dbChannel *dbChan,


### PR DESCRIPTION
This request

* Fixes #5 (pvaSrv handling of request for structure element returns whole struct)
* Fixes #3 (pva requests for value.index field of enum PV use wrong structure)
* As a by product only changed fields are sent (changed bitset set on per-field not per-structure basis for structure fields)
* Refactors  Property data function getPropertyData() into functions for display, control and valueAlarm properties.

An API change was needed to sensible fix this as createPVStructure() needs the pvRequest and not just the property mask in order to create the correct structure. (Adding every subfield to the property mask would be silly and anyway wouldn't work without an API change when an int is 32 bits wide).

I removed the use of the property classes for alarms, time stamps and display and control structures - they simple don't work for partial structures. Instead I set the individual fields, like you have to for valueAlarm. I could create an intermediate structure but this just doesn't seem sensible and makes the code harder and more likely to go wrong, especially when you get to monitoring.

For a request for the complete structures the behaviour is as before e.g.
```bash
$ pvget -r "value,alarm,timeStamp" double01
double01
epics:nt/NTScalar:1.0 
    double value 8
    alarm_t alarm MAJOR RECORD HIHI_ALARM
    time_t timeStamp 2016-05-13T14:07:18.450 0
```
for substructure's we return the correct partial structure, e.g.
```bash
$ pvget -r "value,alarm.message,timeStamp{secondsPastEpoch,nanoseconds,userTag},\
     display{limitLow,limitHigh},valueAlarm.hysteresis" double01
double01
structure 
    double value 8
    structure alarm
        string message HIHI_ALARM
    time_t timeStamp 2016-05-13T14:07:18.450 0
    structure display
        double limitLow 0
        double limitHigh 10
    structure valueAlarm
        double hysteresis 0
```

The fix for #5 enables the fix for #3 to be made. So now enums are treated correctly.

For a complete enum structure the behaviour is as before:
```bash
$ pvget -r "value" enum01
enum01
epics:nt/NTEnum:1.0 
    enum_t value zero
```
For a request of index or choices field we return the correct partial structure
```bash
$ pvget -r "value.index" enum01
enum01
structure 
    structure value
        int index 0

$ pvget -r "value.choices" enum01
enum01
structure 
    structure value
        string[] choices [zero,one,two,three]
```
Puts to the index field handle correctly (putting to choices does not set the choices, as before, but is handled gracefully.

```
$ pvput enum01 one
Old : enum01                         zero
New : enum01                         one
$ pvput -r "value.index" enum01 2
Old : 
structure 
    structure value
        int index 1

New : 
structure 
    structure value
        int index 2
```
Menus and device types are also suitably handled:

```bash
pvget -r "value.choices" double01.SCAN
double01.SCAN
structure 
    structure value
        string[] choices [Passive,Event,I/O Intr,10 second,5 second,2 second,1 second,.5 second,.2 second,.1 second]

$ pvget -r "value.index" double01.DTYP
double01.DTYP
structure 
    structure value
        int index 0

$ pvget -r "value.index" double01.SCAN
double01.SCAN
structure 
    structure value
        int index 0

$ pvget -r "value.choices" double01.SCAN
double01.SCAN
structure 
    structure value
        string[] choices [Passive,Event,I/O Intr,10 second,5 second,2 second,1 second,.5 second,.2 second,.1 second]
```
I've given this a good amount of testing against 3.14.12.3 and 3.15.3. I've tested all the possible combinations of behaviour for complete structures for a range of pv types, each individual field for a range of types and a good cross section of combinations. I've also tried various non VAL fields. In all cases I've seen the correct structure for sensible requests and  sensible behaviour or graceful failure for silly ones. Nothing's made it crash (yet).
