### PR TITLE
Set format field correctly for non-floating point types

### DIFF
--- a/src/dbPv/3.14/dbUtil.cpp
+++ b/src/dbPv/3.14/dbUtil.cpp
@@ -489,25 +489,37 @@ void  DbUtil::getDisplayData(
                 }
             }
         }
-        if(prset && prset->get_precision) {
-            PVStringPtr formatField = displayField->getSubField<PVString>("format");
-            if (formatField.get()) {
-                get_precision gprec = (get_precision)(prset->get_precision);
-                gprec(&dbAddr,&precision);
-                string format;
-                if(precision>0) {
-                    char fmt[16];
-                    sprintf(fmt,"%%.%ldf",precision);
-                    format = string(fmt);
+        PVStringPtr formatField = displayField->getSubField<PVString>("format");
+        if (formatField.get()) {
+            string format;
+            ScalarType scalarType = getScalarType(requester, dbAddr);
+            if (scalarType == pvFloat || scalarType == pvDouble) {
+                const static string defaultFormat("%f");
+                if(prset && prset->get_precision) {
+                    get_precision gprec = (get_precision)(prset->get_precision);
+                    gprec(&dbAddr,&precision);
+                    if(precision>0) {
+                        char fmt[16];
+                        sprintf(fmt,"%%.%ldf",precision);
+                        format = string(fmt);
+                    } else {
+                        format = defaultFormat;
+                    }
                 } else {
-                    const static string defaultFormat("%f");
                     format = defaultFormat;
                 }
-                if (format != formatField->get()) {
-                    formatField->put(format);
-                    if (bitSet.get()) 
-                       bitSet->set(formatField->getFieldOffset());
-                }
+            } else if (scalarType == pvString)
+                format="%s";
+            else if (scalarType == pvUByte || scalarType == pvUShort ||
+                     scalarType == pvUInt  || scalarType == pvULong) {
+                format="%u";
+            } else {
+                format="%d";
+            }
+            if (format != formatField->get()) {
+                formatField->put(format);
+                if (bitSet.get()) 
+                   bitSet->set(formatField->getFieldOffset());
             }
         }
         struct dbr_grDouble graphics;

--- a/src/dbPv/3.15/dbUtil.cpp
+++ b/src/dbPv/3.15/dbUtil.cpp
@@ -506,25 +506,37 @@ void  DbUtil::getDisplayData(
                 }
             }
         }
-        if(prset && prset->get_precision) {
-            PVStringPtr formatField = displayField->getSubField<PVString>("format");
-            if (formatField.get()) {
-                get_precision gprec = (get_precision)(prset->get_precision);
-                gprec(&dbChan->addr,&precision);
-                string format;
-                if(precision>0) {
-                    char fmt[16];
-                    sprintf(fmt,"%%.%ldf",precision);
-                    format = string(fmt);
+        PVStringPtr formatField = displayField->getSubField<PVString>("format");
+        if (formatField.get()) {
+            string format;
+            ScalarType scalarType = getScalarType(requester, dbChan);
+            if (scalarType == pvFloat || scalarType == pvDouble) {
+                if(prset && prset->get_precision) {
+                    get_precision gprec = (get_precision)(prset->get_precision);
+                    gprec(&dbChan->addr,&precision);
+                    if(precision>0) {
+                        char fmt[16];
+                        sprintf(fmt,"%%.%ldf",precision);
+                        format = string(fmt);
+                    } else {
+                        const static string defaultFormat("%f");
+                        format = defaultFormat;
+                    }
                 } else {
-                    const static string defaultFormat("%f");
-                    format = defaultFormat;
+                    format="%f";
                 }
-                if (format != formatField->get()) {
-                    formatField->put(format);
-                    if (bitSet.get()) 
-                       bitSet->set(formatField->getFieldOffset());
-                }
+            } else if (scalarType == pvString)
+                format="%s";
+            else if (scalarType == pvUByte || scalarType == pvUShort ||
+                     scalarType == pvUInt  || scalarType == pvULong) {
+                format="%u";
+            } else {
+                format="%d";
+            }
+            if (format != formatField->get()) {
+                formatField->put(format);
+                if (bitSet.get()) 
+                   bitSet->set(formatField->getFieldOffset());
             }
         }
         struct dbr_grDouble graphics;


### PR DESCRIPTION
Strictly speaking  I don't think we have ever agreed what the value of the display.format field should be, but we've used a (C?) sprintf-style format string in both pvaSrv and caProvider since time immemorial. However caProvider used %d for integer types whereas pvaSrv uses %f. 

In lieu of a standard I suggest choosing something sensible and consistent:

Bring pvaSrv in line with caProvider by setting format to %d for integers.
caProvider doesn't do unsigned but I suggest %u for pvaSrv in this case.

caProvider and pvaSrv are now in line with respect to display.format except for unsigned types which are converted to signed or floating point types in caProvider. (In this case the caProvider value is consistent with the converted type.)