### PR TITLE
Add -include of exampleTop/configure/RELEASE.local

### DIFF
--- a/exampleTop/configure/RELEASE
+++ b/exampleTop/configure/RELEASE
@@ -26,5 +26,5 @@
 PVASRV = $(TOP)/..
 
 -include $(TOP)/../../RELEASE.local
--include $(TOP)/configure/RELEASE.local
 -include $(TOP)/../configure/RELEASE.local
+-include $(TOP)/configure/RELEASE.local

--- a/exampleTop/configure/RELEASE
+++ b/exampleTop/configure/RELEASE
@@ -26,4 +26,5 @@
 PVASRV = $(TOP)/..
 
 -include $(TOP)/../../RELEASE.local
+-include $(TOP)/configure/RELEASE.local
 -include $(TOP)/../configure/RELEASE.local

--- a/testTop/configure/RELEASE
+++ b/testTop/configure/RELEASE
@@ -29,8 +29,8 @@
 
 PVASRV = $(TOP)/..
 -include $(TOP)/../../RELEASE.local
--include $(TOP)/configure/RELEASE.local
 -include $(TOP)/../configure/RELEASE.local
+-include $(TOP)/configure/RELEASE.local
 
 # If you copied these tests from pvaSrv to be built as a
 # standalone TOP, define

--- a/testTop/configure/RELEASE
+++ b/testTop/configure/RELEASE
@@ -29,6 +29,7 @@
 
 PVASRV = $(TOP)/..
 -include $(TOP)/../../RELEASE.local
+-include $(TOP)/configure/RELEASE.local
 -include $(TOP)/../configure/RELEASE.local
 
 # If you copied these tests from pvaSrv to be built as a


### PR DESCRIPTION
Add -include of exampleTop/configure/RELEASE.local to allow configuration 
from locations relative to exampleTop.

Ditto for testTop/configure/RELEASE.local

The use case here is building the same git tag for different versions of base, 
where EPICS_BASE and EPICS_MODULES are defined here:
$(EPICS_SITE_TOP)/$(BASE_VERSION)/modules/RELEASE.local
and module releases are here
$(EPICS_SITE_TOP)/$(BASE_VERSION)/modules/MODULE_NAME/MODULE_VERSION

For each module, we have these -includes in RELEASE.local files
$(TOP)/configure/RELEASE.local
      -include $(TOP)/../../RELEASE.local
$(TOP)/exampleTop/configure/RELEASE.local
      -include $(TOP)/../../../RELEASE.local

